### PR TITLE
SABRE-54 Tests for CORS

### DIFF
--- a/src/test/java/com/linagora/dav/contracts/CalJsonContract.java
+++ b/src/test/java/com/linagora/dav/contracts/CalJsonContract.java
@@ -247,19 +247,19 @@ public abstract class CalJsonContract {
 
         given().log().all()
             .header("Origin", "https://it-calendar")
-            .options("/calendars/" + testUser.id() + ".json").prettyPeek()
+            .options("/calendars/" + testUser.id() + ".json")
             .then()
             .statusCode(200);
 
         given().log().all()
             .header("Origin", "https://it-calendar")
-            .options("/calendars/" + testUser.id() + "/events.json").prettyPeek()
+            .options("/calendars/" + testUser.id() + "/events.json")
         .then()
             .statusCode(200);
 
         given().log().all()
             .header("Origin", "https://it-calendar")
-            .options("/calendars/" + testUser.id() + "/" + testUser.id() + ".json").prettyPeek()
+            .options("/calendars/" + testUser.id() + "/" + testUser.id() + ".json")
         .then()
             .statusCode(200);
     }

--- a/src/test/java/com/linagora/dav/contracts/CalJsonContract.java
+++ b/src/test/java/com/linagora/dav/contracts/CalJsonContract.java
@@ -242,6 +242,29 @@ public abstract class CalJsonContract {
     }
 
     @Test
+    public void shouldSupportOptions() {
+        OpenPaasUser testUser = dockerExtension().newTestUser();
+
+        given().log().all()
+            .header("Origin", "https://it-calendar")
+            .options("/calendars/" + testUser.id() + ".json").prettyPeek()
+            .then()
+            .statusCode(200);
+
+        given().log().all()
+            .header("Origin", "https://it-calendar")
+            .options("/calendars/" + testUser.id() + "/events.json").prettyPeek()
+        .then()
+            .statusCode(200);
+
+        given().log().all()
+            .header("Origin", "https://it-calendar")
+            .options("/calendars/" + testUser.id() + "/" + testUser.id() + ".json").prettyPeek()
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
     void shouldListEvents() {
         OpenPaasUser testUser = dockerExtension().newTestUser();
 

--- a/src/test/java/com/linagora/dav/sabrev4/SabreV4CalJsonTest.java
+++ b/src/test/java/com/linagora/dav/sabrev4/SabreV4CalJsonTest.java
@@ -20,6 +20,7 @@ package com.linagora.dav.sabrev4;
 
 import static com.linagora.dav.DockerTwakeCalendarSetup.SABRE_V4;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linagora.dav.DockerTwakeCalendarExtension;
@@ -32,5 +33,11 @@ public class SabreV4CalJsonTest extends CalJsonContract {
     @Override
     public DockerTwakeCalendarExtension dockerExtension() {
         return dockerExtension;
+    }
+
+    @Disabled("CORS fails on Sabre v4 CF https://github.com/linagora/esn-sabre/issues/54")
+    @Override
+    public void shouldSupportOptions() {
+
     }
 }

--- a/src/test/java/com/linagora/dav/sabrev4/SabreV4CalJsonTest.java
+++ b/src/test/java/com/linagora/dav/sabrev4/SabreV4CalJsonTest.java
@@ -20,7 +20,6 @@ package com.linagora.dav.sabrev4;
 
 import static com.linagora.dav.DockerTwakeCalendarSetup.SABRE_V4;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linagora.dav.DockerTwakeCalendarExtension;
@@ -33,11 +32,5 @@ public class SabreV4CalJsonTest extends CalJsonContract {
     @Override
     public DockerTwakeCalendarExtension dockerExtension() {
         return dockerExtension;
-    }
-
-    @Disabled("CORS fails on Sabre v4 CF https://github.com/linagora/esn-sabre/issues/54")
-    @Override
-    public void shouldSupportOptions() {
-
     }
 }


### PR DESCRIPTION
I struggled because the `Origin` header is actually mandatory for Sabre CORS to work.

I thought one time that this was a config issue and had **pain** understanding how Sabre config works (using a script to provide a `/var/www/config.json` file that is later reused in numerous places... Madness... )

It perfectly documents https://github.com/linagora/esn-sabre/issues/54 regression.