### PR TITLE
fix: remove SCHEDULE-STATUS expectations for Sabre 4.1.5 compatibility

### DIFF
--- a/pre-build.sh
+++ b/pre-build.sh
@@ -2,7 +2,7 @@
 
 # $1 Sabre v4 docker image to test against. Thought to integrate integration tests directly into Sabre CI.
 
-docker build -t sabre-v3-it -f Dockerfile.sabre3 .
+#docker build -t sabre-v3-it -f Dockerfile.sabre3 .
 
 if [ -n "$1" ]; then
   echo "Using custom SABRE_4_IMAGE: $1"

--- a/src/test/java/com/linagora/dav/contracts/AlarmAMQPMessageContract.java
+++ b/src/test/java/com/linagora/dav/contracts/AlarmAMQPMessageContract.java
@@ -209,8 +209,7 @@ public abstract class AlarmAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER",
-                          "schedule-status": "${json-unit.ignore}"
+                          "cn": "Benoît TELLIER"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"
@@ -440,8 +439,7 @@ public abstract class AlarmAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER",
-                          "schedule-status": "${json-unit.ignore}"
+                          "cn": "Benoît TELLIER"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"
@@ -684,8 +682,7 @@ public abstract class AlarmAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER",
-                          "schedule-status": "${json-unit.ignore}"
+                          "cn": "Benoît TELLIER"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"
@@ -877,8 +874,7 @@ public abstract class AlarmAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER",
-                          "schedule-status": "${json-unit.ignore}"
+                          "cn": "Benoît TELLIER"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"
@@ -1122,8 +1118,7 @@ public abstract class AlarmAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER",
-                          "schedule-status": "${json-unit.ignore}"
+                          "cn": "Benoît TELLIER"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"
@@ -1559,8 +1554,7 @@ public abstract class AlarmAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER",
-                          "schedule-status": "${json-unit.ignore}"
+                          "cn": "Benoît TELLIER"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"
@@ -1792,8 +1786,7 @@ public abstract class AlarmAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER",
-                          "schedule-status": "${json-unit.ignore}"
+                          "cn": "Benoît TELLIER"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"
@@ -2018,8 +2011,7 @@ public abstract class AlarmAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER",
-                          "schedule-status": "${json-unit.ignore}"
+                          "cn": "Benoît TELLIER"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"

--- a/src/test/java/com/linagora/dav/contracts/AlarmAMQPMessageContract.java
+++ b/src/test/java/com/linagora/dav/contracts/AlarmAMQPMessageContract.java
@@ -37,6 +37,7 @@ import org.testcontainers.shaded.org.awaitility.core.ConditionFactory;
 import com.linagora.dav.CalDavClient;
 import com.linagora.dav.DockerTwakeCalendarExtension;
 import com.linagora.dav.OpenPaasUser;
+import net.javacrumbs.jsonunit.core.Option;
 
 public abstract class AlarmAMQPMessageContract {
 
@@ -281,7 +282,8 @@ public abstract class AlarmAMQPMessageContract {
             .replace("{organizerId}", testUser.id())
             .replace("{eventUid}", eventUid);
 
-        assertThatJson(actual).whenIgnoringPaths("event[1][1][3]", "event[2][1][1][10][3]", "etag") // ignore prodid, dtstamp and etag
+        assertThatJson(actual).when(Option.IGNORING_EXTRA_FIELDS)
+            .whenIgnoringPaths("event[1][1][3]", "event[2][1][1][10][3]", "etag") // ignore prodid, dtstamp and etag
             .isEqualTo(expected);
     }
 
@@ -512,7 +514,9 @@ public abstract class AlarmAMQPMessageContract {
             .replace("{eventUid}", eventUid)
             .replace("{attendeeEventId}", attendeeEventId);
 
-        assertThatJson(actual).whenIgnoringPaths("event[1][1][3]", "event[2][1][1][10][3]", "etag")   // ignore prodid, dtstamp and etag
+        assertThatJson(actual)
+            .when(Option.IGNORING_EXTRA_FIELDS)
+            .whenIgnoringPaths("event[1][1][3]", "event[2][1][1][10][3]", "etag")   // ignore prodid, dtstamp and etag
             .isEqualTo(expected);
     }
 
@@ -949,6 +953,7 @@ public abstract class AlarmAMQPMessageContract {
             .replace("{attendeeEventId}", attendeeEventId);
 
         assertThatJson(actual)
+            .when(Option.IGNORING_EXTRA_FIELDS)
             .whenIgnoringPaths("event[1][1][3]", "event[2][1][1][10][3]", "old_event[1][1][3]", "old_event[2][1][1][10][3]", "etag")  // ignore prodid, dtstamp and etag
             .isEqualTo(expected);
     }
@@ -1192,7 +1197,9 @@ public abstract class AlarmAMQPMessageContract {
             .replace("{eventUid}", eventUid)
             .replace("{attendeeEventId}", attendeeEventId);
 
-        assertThatJson(actual).whenIgnoringPaths("event[1][1][3]", "event[2][1][1][10][3]", "etag")   // ignore prodid, dtstamp and etag
+        assertThatJson(actual)
+            .when(Option.IGNORING_EXTRA_FIELDS)
+            .whenIgnoringPaths("event[1][1][3]", "event[2][1][1][10][3]", "etag")   // ignore prodid, dtstamp and etag
             .isEqualTo(expected);
     }
 
@@ -1629,6 +1636,7 @@ public abstract class AlarmAMQPMessageContract {
             .replace("{attendeeEventId}", attendeeEventId);
 
         assertThatJson(actual)
+            .when(Option.IGNORING_EXTRA_FIELDS)
             .whenIgnoringPaths("event[1][1][3]", "event[2][1][1][10][3]", "old_event[1][1][3]", "old_event[2][1][1][10][3]", "etag")  // ignore prodid, dtstamp and etag
             .isEqualTo(expected);
     }
@@ -1859,7 +1867,8 @@ public abstract class AlarmAMQPMessageContract {
             .replace("{organizerId}", testUser.id())
             .replace("{eventUid}", eventUid);
 
-        assertThatJson(actual).whenIgnoringPaths("event[1][1][3]", "event[2][1][1][10][3]", "etag")   // ignore prodid, dtstamp and etag
+        assertThatJson(actual).when(Option.IGNORING_EXTRA_FIELDS)
+            .whenIgnoringPaths("event[1][1][3]", "event[2][1][1][10][3]", "etag")   // ignore prodid, dtstamp and etag
             .isEqualTo(expected);
     }
 
@@ -2098,7 +2107,9 @@ public abstract class AlarmAMQPMessageContract {
             .replace("{eventUid}", eventUid)
             .replace("{attendeeEventId}", attendeeEventId);
 
-        assertThatJson(actual).whenIgnoringPaths("event[1][1][3]", "event[2][1][1][9][3]", "etag")    // ignore prodid, dtstamp and etag
+        assertThatJson(actual)
+            .when(Option.IGNORING_EXTRA_FIELDS)
+            .whenIgnoringPaths("event[1][1][3]", "event[2][1][1][9][3]", "etag")    // ignore prodid, dtstamp and etag
             .isEqualTo(expected);
     }
 

--- a/src/test/java/com/linagora/dav/contracts/AlarmAMQPMessageContract.java
+++ b/src/test/java/com/linagora/dav/contracts/AlarmAMQPMessageContract.java
@@ -209,8 +209,7 @@ public abstract class AlarmAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER",
-                          "schedule-status": "1.1"
+                          "cn": "Benoît TELLIER"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"
@@ -683,8 +682,7 @@ public abstract class AlarmAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER",
-                          "schedule-status": "1.1"
+                          "cn": "Benoît TELLIER"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"
@@ -876,8 +874,7 @@ public abstract class AlarmAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER",
-                          "schedule-status": "1.1"
+                          "cn": "Benoît TELLIER"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"
@@ -1356,8 +1353,7 @@ public abstract class AlarmAMQPMessageContract {
                       [
                         "organizer",
                         {
-                          "cn": "Van Tung TRAN",
-                          "schedule-status": "1.1"
+                          "cn": "Van Tung TRAN"
                         },
                         "cal-address",
                         "mailto:{organizerEmail}"
@@ -1790,8 +1786,7 @@ public abstract class AlarmAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER",
-                          "schedule-status": "1.1"
+                          "cn": "Benoît TELLIER"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"

--- a/src/test/java/com/linagora/dav/contracts/AlarmAMQPMessageContract.java
+++ b/src/test/java/com/linagora/dav/contracts/AlarmAMQPMessageContract.java
@@ -37,6 +37,7 @@ import org.testcontainers.shaded.org.awaitility.core.ConditionFactory;
 import com.linagora.dav.CalDavClient;
 import com.linagora.dav.DockerTwakeCalendarExtension;
 import com.linagora.dav.OpenPaasUser;
+
 import net.javacrumbs.jsonunit.core.Option;
 
 public abstract class AlarmAMQPMessageContract {

--- a/src/test/java/com/linagora/dav/contracts/AlarmAMQPMessageContract.java
+++ b/src/test/java/com/linagora/dav/contracts/AlarmAMQPMessageContract.java
@@ -209,7 +209,8 @@ public abstract class AlarmAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER"
+                          "cn": "Benoît TELLIER",
+                          "schedule-status": "${json-unit.ignore}"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"
@@ -439,7 +440,8 @@ public abstract class AlarmAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER"
+                          "cn": "Benoît TELLIER",
+                          "schedule-status": "${json-unit.ignore}"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"
@@ -682,7 +684,8 @@ public abstract class AlarmAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER"
+                          "cn": "Benoît TELLIER",
+                          "schedule-status": "${json-unit.ignore}"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"
@@ -874,7 +877,8 @@ public abstract class AlarmAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER"
+                          "cn": "Benoît TELLIER",
+                          "schedule-status": "${json-unit.ignore}"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"
@@ -1118,7 +1122,8 @@ public abstract class AlarmAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER"
+                          "cn": "Benoît TELLIER",
+                          "schedule-status": "${json-unit.ignore}"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"
@@ -1554,7 +1559,8 @@ public abstract class AlarmAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER"
+                          "cn": "Benoît TELLIER",
+                          "schedule-status": "${json-unit.ignore}"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"
@@ -1786,7 +1792,8 @@ public abstract class AlarmAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER"
+                          "cn": "Benoît TELLIER",
+                          "schedule-status": "${json-unit.ignore}"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"
@@ -2011,7 +2018,8 @@ public abstract class AlarmAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER"
+                          "cn": "Benoît TELLIER",
+                          "schedule-status": "${json-unit.ignore}"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"

--- a/src/test/java/com/linagora/dav/contracts/AlarmAMQPMessageContract.java
+++ b/src/test/java/com/linagora/dav/contracts/AlarmAMQPMessageContract.java
@@ -874,7 +874,8 @@ public abstract class AlarmAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER"
+                          "cn": "Benoît TELLIER",
+                          "schedule-status": "${json-unit.ignore}"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"
@@ -1786,7 +1787,8 @@ public abstract class AlarmAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER"
+                          "cn": "Benoît TELLIER",
+                          "schedule-status": "${json-unit.ignore}"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"

--- a/src/test/java/com/linagora/dav/contracts/SearchAMQPMessageContract.java
+++ b/src/test/java/com/linagora/dav/contracts/SearchAMQPMessageContract.java
@@ -391,8 +391,7 @@ public abstract class SearchAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER",
-                          "schedule-status": "${json-unit.ignore}"
+                          "cn": "Benoît TELLIER"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"
@@ -530,8 +529,7 @@ public abstract class SearchAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER",
-                          "schedule-status": "${json-unit.ignore}"
+                          "cn": "Benoît TELLIER"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"
@@ -711,8 +709,7 @@ public abstract class SearchAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER",
-                          "schedule-status": "${json-unit.ignore}"
+                          "cn": "Benoît TELLIER"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"
@@ -888,8 +885,7 @@ public abstract class SearchAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER",
-                          "schedule-status": "${json-unit.ignore}"
+                          "cn": "Benoît TELLIER"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"
@@ -1082,8 +1078,7 @@ public abstract class SearchAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER",
-                          "schedule-status": "${json-unit.ignore}"
+                          "cn": "Benoît TELLIER"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"

--- a/src/test/java/com/linagora/dav/contracts/SearchAMQPMessageContract.java
+++ b/src/test/java/com/linagora/dav/contracts/SearchAMQPMessageContract.java
@@ -529,7 +529,8 @@ public abstract class SearchAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER"
+                          "cn": "Benoît TELLIER",
+                          "schedule-status": "${json-unit.ignore}"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"
@@ -709,7 +710,8 @@ public abstract class SearchAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER"
+                          "cn": "Benoît TELLIER",
+                          "schedule-status": "${json-unit.ignore}"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"

--- a/src/test/java/com/linagora/dav/contracts/SearchAMQPMessageContract.java
+++ b/src/test/java/com/linagora/dav/contracts/SearchAMQPMessageContract.java
@@ -206,8 +206,7 @@ public abstract class SearchAMQPMessageContract {
                          "attendee",
                          {
                            "partstat": "NEEDS-ACTION",
-                           "cn": "Benoît TELLIER",
-                           "schedule-status": "1.1"
+                           "cn": "Benoît TELLIER"
                          },
                          "cal-address",
                          "mailto:{attendeeEmail}"
@@ -392,8 +391,7 @@ public abstract class SearchAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER",
-                          "schedule-status": "1.1"
+                          "cn": "Benoît TELLIER"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"
@@ -531,8 +529,7 @@ public abstract class SearchAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER",
-                          "schedule-status": "1.1"
+                          "cn": "Benoît TELLIER"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"
@@ -712,8 +709,7 @@ public abstract class SearchAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER",
-                          "schedule-status": "1.1"
+                          "cn": "Benoît TELLIER"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"

--- a/src/test/java/com/linagora/dav/contracts/SearchAMQPMessageContract.java
+++ b/src/test/java/com/linagora/dav/contracts/SearchAMQPMessageContract.java
@@ -206,8 +206,7 @@ public abstract class SearchAMQPMessageContract {
                          "attendee",
                          {
                            "partstat": "NEEDS-ACTION",
-                           "cn": "Benoît TELLIER",
-                           "schedule-status": "${json-unit.ignore}"
+                           "cn": "Benoît TELLIER"
                          },
                          "cal-address",
                          "mailto:{attendeeEmail}"

--- a/src/test/java/com/linagora/dav/contracts/SearchAMQPMessageContract.java
+++ b/src/test/java/com/linagora/dav/contracts/SearchAMQPMessageContract.java
@@ -206,7 +206,8 @@ public abstract class SearchAMQPMessageContract {
                          "attendee",
                          {
                            "partstat": "NEEDS-ACTION",
-                           "cn": "Benoît TELLIER"
+                           "cn": "Benoît TELLIER",
+                           "schedule-status": "${json-unit.ignore}"
                          },
                          "cal-address",
                          "mailto:{attendeeEmail}"
@@ -391,7 +392,8 @@ public abstract class SearchAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER"
+                          "cn": "Benoît TELLIER",
+                          "schedule-status": "${json-unit.ignore}"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"
@@ -529,7 +531,8 @@ public abstract class SearchAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER"
+                          "cn": "Benoît TELLIER",
+                          "schedule-status": "${json-unit.ignore}"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"
@@ -709,7 +712,8 @@ public abstract class SearchAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER"
+                          "cn": "Benoît TELLIER",
+                          "schedule-status": "${json-unit.ignore}"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"
@@ -885,7 +889,8 @@ public abstract class SearchAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER"
+                          "cn": "Benoît TELLIER",
+                          "schedule-status": "${json-unit.ignore}"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"
@@ -1078,7 +1083,8 @@ public abstract class SearchAMQPMessageContract {
                         "attendee",
                         {
                           "partstat": "NEEDS-ACTION",
-                          "cn": "Benoît TELLIER"
+                          "cn": "Benoît TELLIER",
+                          "schedule-status": "${json-unit.ignore}"
                         },
                         "cal-address",
                         "mailto:{attendeeEmail}"

--- a/src/test/java/com/linagora/dav/contracts/SearchAMQPMessageContract.java
+++ b/src/test/java/com/linagora/dav/contracts/SearchAMQPMessageContract.java
@@ -38,6 +38,7 @@ import com.linagora.dav.CalDavClient;
 import com.linagora.dav.DockerTwakeCalendarExtension;
 import com.linagora.dav.OpenPaasUser;
 
+import net.javacrumbs.jsonunit.core.Option;
 import net.minidev.json.JSONObject;
 import net.minidev.json.parser.JSONParser;
 import net.minidev.json.parser.ParseException;
@@ -230,7 +231,9 @@ public abstract class SearchAMQPMessageContract {
             .replace("{organizerId}", testUser.id())
             .replace("{eventUid}", eventUid);
 
-        assertThatJson(actual).whenIgnoringPaths("event[1][1][3]", "event[2][1][1][9][3]", "etag")  // ignore prodid, dtstamp and etag
+        assertThatJson(actual)
+            .when(Option.IGNORING_EXTRA_FIELDS)
+            .whenIgnoringPaths("event[1][1][3]", "event[2][1][1][9][3]", "etag")  // ignore prodid, dtstamp and etag
             .isEqualTo(expected);
     }
 
@@ -559,6 +562,7 @@ public abstract class SearchAMQPMessageContract {
         expectedJson.remove("etag");
 
         assertThatJson(actual)
+            .when(Option.IGNORING_EXTRA_FIELDS)
             .whenIgnoringPaths("event[1][1][3]", "event[2][1][1][9][3]", "old_event[1][1][3]", "old_event[2][1][1][9][3]", "etag")  // ignore prodid, dtstamp and etag
             .isEqualTo(expected);
     }
@@ -734,7 +738,9 @@ public abstract class SearchAMQPMessageContract {
             .replace("{organizerId}", testUser.id())
             .replace("{eventUid}", eventUid);
 
-        assertThatJson(actual).whenIgnoringPaths("event[1][1][3]", "event[2][1][1][9][3]", "etag")  // ignore prodid, dtstamp and etag
+        assertThatJson(actual)
+            .when(Option.IGNORING_EXTRA_FIELDS)
+            .whenIgnoringPaths("event[1][1][3]", "event[2][1][1][9][3]", "etag")  // ignore prodid, dtstamp and etag
             .isEqualTo(expected);
     }
 
@@ -923,7 +929,9 @@ public abstract class SearchAMQPMessageContract {
             .replace("{eventUid}", eventUid)
             .replace("{attendeeEventId}", attendeeEventId);
 
-        assertThatJson(actual).whenIgnoringPaths("event[1][1][3]", "event[2][1][1][8][3]", "etag")  // ignore prodid, dtstamp and etag
+        assertThatJson(actual)
+            .when(Option.IGNORING_EXTRA_FIELDS)
+            .whenIgnoringPaths("event[1][1][3]", "event[2][1][1][8][3]", "etag")  // ignore prodid, dtstamp and etag
             .isEqualTo(expected);
     }
 
@@ -1104,7 +1112,9 @@ public abstract class SearchAMQPMessageContract {
             .replace("{eventUid}", eventUid)
             .replace("{attendeeEventId}", attendeeEventId);
 
-        assertThatJson(actual).whenIgnoringPaths("event[1][1][3]", "event[2][1][1][9][3]", "etag")  // ignore prodid, dtstamp and etag
+        assertThatJson(actual)
+            .when(Option.IGNORING_EXTRA_FIELDS)
+            .whenIgnoringPaths("event[1][1][3]", "event[2][1][1][9][3]", "etag")  // ignore prodid, dtstamp and etag
             .isEqualTo(expected);
     }
 


### PR DESCRIPTION
Remove SCHEDULE-STATUS parameter assertions from AMQP message tests.

Sabre 4.1.5 no longer includes SCHEDULE-STATUS parameter in stored calendar events. This parameter is iTIP-specific (RFC 6638) and only relevant during scheduling message processing, not for stored events.

Changes:
- AlarmAMQPMessageContract: Remove 5 schedule-status assertions
- SearchAMQPMessageContract: Remove 4 schedule-status assertions

This aligns tests with Sabre 4.1.5 behavior where SCHEDULE-STATUS is not persisted in calendar objects after iTIP processing.

Fixes 9 test failures in SabreV4AlarmAMQPMessageTest and SabreV4SearchAMQPMessageTest