### PR TITLE
Rebuild image sabre-v3-it in pre-build.sh script

### DIFF
--- a/Dockerfile.sabre3
+++ b/Dockerfile.sabre3
@@ -1,3 +1,3 @@
-FROM linagora/esn-sabre:lng-21-10-2025
+FROM linagora/esn-sabre:lng-23-10-2025
 
 COPY src/test/resources/twake-calendar-side-service-conf/jwt_publickey /var/www/config/esn.key.pub

--- a/pre-build.sh
+++ b/pre-build.sh
@@ -2,7 +2,7 @@
 
 # $1 Sabre v4 docker image to test against. Thought to integrate integration tests directly into Sabre CI.
 
-#docker build -t sabre-v3-it -f Dockerfile.sabre3 .
+docker build -t sabre-v3-it -f Dockerfile.sabre3 .
 
 if [ -n "$1" ]; then
   echo "Using custom SABRE_4_IMAGE: $1"


### PR DESCRIPTION
The pr https://github.com/linagora/twake-calendar-integration-tests/pull/91/files  updates the image for Sabre 3: `linagora/esn-sabre:lng-06-10-2025-2` -> `linagora/esn-sabre:lng-21-10-2025`, but the image rebuild was not enabled. 