### PR TITLE
test: make syncTokenCanReportDeleted compatible with Sabre 4.7

### DIFF
--- a/src/test/java/com/linagora/dav/contracts/CalDavContract.java
+++ b/src/test/java/com/linagora/dav/contracts/CalDavContract.java
@@ -47,9 +47,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.testcontainers.shaded.org.awaitility.Awaitility;
 import org.testcontainers.shaded.org.awaitility.core.ConditionFactory;
+import org.w3c.dom.Node;
 import org.xmlunit.assertj3.XmlAssert;
 import org.xmlunit.diff.ComparisonResult;
+import org.xmlunit.diff.DefaultNodeMatcher;
 import org.xmlunit.diff.DifferenceEvaluator;
+import org.xmlunit.diff.ElementSelectors;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.linagora.dav.CalDavClient;
@@ -852,6 +855,9 @@ public abstract class CalDavContract {
                 " <d:sync-token>http://sabre.io/ns/sync/3</d:sync-token>\n" +
                 "</d:multistatus>")
             .ignoreChildNodesOrder()
+            .ignoreWhitespace()
+            .withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byNameAndAllAttributes))
+            .withNodeFilter(node -> !(node.getNodeType() == Node.ELEMENT_NODE && "propstat".equals(node.getLocalName())))
             .areSimilar();
     }
 


### PR DESCRIPTION
Adapt XML response handling to changes introduced in Sabre 4.7.

Detected at: https://github.com/linagora/esn-sabre/pull/191#issuecomment-3460186824

Before
```xml
<d:response>
  <d:status>HTTP/1.1 404 Not Found</d:status>
  <d:href>/calendars/.../abcd.ics</d:href>
  <d:propstat>
    <d:prop/>
    <d:status>HTTP/1.1 418 I'm a teapot</d:status>
  </d:propstat>
</d:response>
```

After
```xml
<d:response>
  <d:href>/calendars/.../abcd.ics</d:href>
  <d:status>HTTP/1.1 404 Not Found</d:status>
</d:response>
```
