### PR TITLE
test(alarm): ensure no alarm:request is published for unaffected attendee

### DIFF
--- a/Dockerfile.sabre4
+++ b/Dockerfile.sabre4
@@ -1,4 +1,4 @@
-ARG SABRE_4_IMAGE="linagora/esn-sabre:sabre-4_1_5-17-11-2025"
+ARG SABRE_4_IMAGE="linagora/esn-sabre:sabre-4_1_5-18-11-2025"
 
 FROM ${SABRE_4_IMAGE}
 

--- a/src/test/java/com/linagora/dav/contracts/AlarmAMQPMessageContract.java
+++ b/src/test/java/com/linagora/dav/contracts/AlarmAMQPMessageContract.java
@@ -48,6 +48,7 @@ import com.linagora.dav.CalendarURL;
 import com.linagora.dav.DockerTwakeCalendarExtension;
 import com.linagora.dav.ITIPJsonBodyRequest;
 import com.linagora.dav.OpenPaasUser;
+import com.rabbitmq.client.GetResponse;
 
 import net.javacrumbs.jsonunit.core.Option;
 
@@ -2940,5 +2941,119 @@ public abstract class AlarmAMQPMessageContract {
         // THEN we have a message
         String actual = new String(getMessageFromQueue(), StandardCharsets.UTF_8);
         Assertions.assertThat(actual).isNotNull();
+    }
+
+    @Test
+    void shouldNotPublishAlarmRequestForUnaffectedAttendeeWhenAnotherAttendeeUpdatesPartStat() throws Exception {
+        OpenPaasUser cedric = dockerExtension().newTestUser();
+        OpenPaasUser bob = dockerExtension().newTestUser();
+        OpenPaasUser alice = dockerExtension().newTestUser();
+
+        // GIVEN the organizer creates an event with Bob + Alice + VALARM
+        String eventUid = UUID.randomUUID().toString();
+        String calendarData = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Sabre//Sabre VObject 4.1.3//EN
+            CALSCALE:GREGORIAN
+            BEGIN:VTIMEZONE
+            TZID:Asia/Ho_Chi_Minh
+            BEGIN:STANDARD
+            TZOFFSETFROM:+0700
+            TZOFFSETTO:+0700
+            TZNAME:ICT
+            DTSTART:19700101T000000
+            END:STANDARD
+            END:VTIMEZONE
+            BEGIN:VEVENT
+            UID:{eventUid}
+            SEQUENCE:1
+            DTSTART;TZID=Asia/Ho_Chi_Minh:30250101T090000
+            DTEND;TZID=Asia/Ho_Chi_Minh:30250101T100000
+            SUMMARY:Team sync
+            LOCATION:Meeting Room A
+            DESCRIPTION:Discuss weekly plan
+            ORGANIZER;CN=Cedric:mailto:{organizerEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;CN=Bob:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;CN=Alice:mailto:{aliceEmail}
+            BEGIN:VALARM
+            TRIGGER:-PT10M
+            ACTION:EMAIL
+            ATTENDEE:mailto:{bobEmail}
+            SUMMARY:test alarm
+            DESCRIPTION:This is an automatic alarm sent by OpenPaas
+            END:VALARM
+            END:VEVENT
+            END:VCALENDAR
+            """
+            .replace("{eventUid}", eventUid)
+            .replace("{organizerEmail}", cedric.email())
+            .replace("{bobEmail}", bob.email())
+            .replace("{aliceEmail}", alice.email());
+        calDavClient.upsertCalendarEvent(cedric, eventUid, calendarData);
+
+        // Ensure attendee copies are created
+        awaitAtMost.until(() -> calDavClient.findFirstEventId(bob), Optional::isPresent);
+        awaitAtMost.until(() -> calDavClient.findFirstEventId(alice), Optional::isPresent);
+
+        // WHEN Bob accepts the invitation
+        String bobEventId = calDavClient.findFirstEventId(bob).get();
+
+        String acceptedIcs = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Sabre//Sabre VObject 4.1.3//EN
+            CALSCALE:GREGORIAN
+            BEGIN:VTIMEZONE
+            TZID:Asia/Ho_Chi_Minh
+            BEGIN:STANDARD
+            TZOFFSETFROM:+0700
+            TZOFFSETTO:+0700
+            TZNAME:ICT
+            DTSTART:19700101T000000
+            END:STANDARD
+            END:VTIMEZONE
+            BEGIN:VEVENT
+            UID:{eventUid}
+            SEQUENCE:2
+            DTSTART;TZID=Asia/Ho_Chi_Minh:30250101T090000
+            DTEND;TZID=Asia/Ho_Chi_Minh:30250101T100000
+            SUMMARY:Team sync
+            LOCATION:Meeting Room A
+            DESCRIPTION:Discuss weekly plan
+            ORGANIZER;CN=Cedric:mailto:{organizerEmail}
+            ATTENDEE;PARTSTAT=ACCEPTED;CN=Bob:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;CN=Alice:mailto:{aliceEmail}
+            BEGIN:VALARM
+            TRIGGER:-PT10M
+            ACTION:EMAIL
+            ATTENDEE:mailto:{bobEmail}
+            SUMMARY:test alarm
+            DESCRIPTION:This is an automatic alarm sent by OpenPaas
+            END:VALARM
+            END:VEVENT
+            END:VCALENDAR
+            """
+            .replace("{eventUid}", eventUid)
+            .replace("{organizerEmail}", cedric.email())
+            .replace("{bobEmail}", bob.email())
+            .replace("{aliceEmail}", alice.email());
+
+        String testQueue = "tcalendar:event:test" + UUID.randomUUID();
+        dockerExtension().getChannel().queueDeclare(testQueue, false, true, true, null);
+        dockerExtension().getChannel().queueBind(testQueue, "calendar:event:alarm:request", "");
+
+        calDavClient.upsertCalendarEvent(bob, bobEventId, acceptedIcs);
+
+        Thread.sleep(1000);
+
+        // THEN  Alice should NOT receive alarm:request
+        GetResponse aliceMsg = dockerExtension()
+            .getChannel()
+            .basicGet(testQueue, true);
+
+        assertThat(aliceMsg)
+            .as("Unexpected alarm:request published for Alice")
+            .isNull();
     }
 }

--- a/src/test/java/com/linagora/dav/contracts/AlarmAMQPMessageContract.java
+++ b/src/test/java/com/linagora/dav/contracts/AlarmAMQPMessageContract.java
@@ -2944,7 +2944,7 @@ public abstract class AlarmAMQPMessageContract {
     }
 
     @Test
-    void shouldNotPublishAlarmRequestForUnaffectedAttendeeWhenAnotherAttendeeUpdatesPartStat() throws Exception {
+    protected void shouldNotPublishAlarmRequestForUnaffectedAttendeeWhenAnotherAttendeeUpdatesPartStat() throws Exception {
         OpenPaasUser cedric = dockerExtension().newTestUser();
         OpenPaasUser bob = dockerExtension().newTestUser();
         OpenPaasUser alice = dockerExtension().newTestUser();

--- a/src/test/java/com/linagora/dav/sabrev3/SabreV3AlarmAMQPMessageTest.java
+++ b/src/test/java/com/linagora/dav/sabrev3/SabreV3AlarmAMQPMessageTest.java
@@ -18,6 +18,8 @@
 
 package com.linagora.dav.sabrev3;
 
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linagora.dav.DockerTwakeCalendarExtensionV3;
@@ -30,5 +32,10 @@ public class SabreV3AlarmAMQPMessageTest extends AlarmAMQPMessageContract {
     @Override
     public DockerTwakeCalendarExtensionV3 dockerExtension() {
         return dockerExtension;
+    }
+
+    @Disabled("https://github.com/linagora/esn-sabre/issues/221 wait to rebuild new image")
+    @Test
+    protected void shouldNotPublishAlarmRequestForUnaffectedAttendeeWhenAnotherAttendeeUpdatesPartStat() {
     }
 }

--- a/src/test/java/com/linagora/dav/sabrev4_7/SabreV4AlarmAMQPMessageTest.java
+++ b/src/test/java/com/linagora/dav/sabrev4_7/SabreV4AlarmAMQPMessageTest.java
@@ -18,6 +18,8 @@
 
 package com.linagora.dav.sabrev4_7;
 
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linagora.dav.DockerTwakeCalendarExtensionV4_7;
@@ -30,5 +32,10 @@ public class SabreV4AlarmAMQPMessageTest extends AlarmAMQPMessageContract {
     @Override
     public DockerTwakeCalendarExtensionV4_7 dockerExtension() {
         return dockerExtension;
+    }
+
+    @Disabled("https://github.com/linagora/esn-sabre/issues/221 wait to rebuild new image")
+    @Test
+    protected void shouldNotPublishAlarmRequestForUnaffectedAttendeeWhenAnotherAttendeeUpdatesPartStat() {
     }
 }


### PR DESCRIPTION
This adds a regression test reproducing the bug where ESN-Sabre publishes a `calendar:event:alarm:request` message to an attendee who did not update their participation status.

ref https://github.com/linagora/esn-sabre/issues/221