### PR TITLE
feat: upgrade Testcontainers core to 2.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>
-            <version>1.21.1</version>
+            <version>2.0.2</version>
         </dependency>
         <dependency>
             <groupId>org.xmlunit</groupId>


### PR DESCRIPTION
To fix the Testcontainers error:
client version 1.32 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version.