### PR TITLE
ISSUE-158 Validate AMQP events for delegation/ registration updates (integration tests)

### DIFF
--- a/Dockerfile.sabre4_7
+++ b/Dockerfile.sabre4_7
@@ -1,4 +1,4 @@
-ARG SABRE_4_7_IMAGE="linagora/esn-sabre:sabre-4_7_0-22-01-2026-4"
+ARG SABRE_4_7_IMAGE="linagora/esn-sabre:sabre-4_7_0-03-02-2026"
 
 FROM ${SABRE_4_7_IMAGE}
 

--- a/src/test/java/com/linagora/dav/sabrev4/SabreV4CalDavDelegationTest.java
+++ b/src/test/java/com/linagora/dav/sabrev4/SabreV4CalDavDelegationTest.java
@@ -56,4 +56,40 @@ public class SabreV4CalDavDelegationTest extends CalDavDelegationContract {
     public void privateOrConfidentialEventShouldBeAnonymizedInDavGet(String eventClass) {
         super.privateOrConfidentialEventShouldBeAnonymizedInDavGet(eventClass);
     }
+
+    @Disabled("Fixed in Sabre 4_7 (com.linagora.dav.sabrev4_7.SabreV4CalDavDelegationTest)")
+    @Override
+    public void amqpShouldPublishDelegationUpdatedForSourceCalendarOnGrant() throws Exception {
+        super.amqpShouldPublishDelegationUpdatedForSourceCalendarOnGrant();
+    }
+
+    @Disabled("Fixed in Sabre 4_7 (com.linagora.dav.sabrev4_7.SabreV4CalDavDelegationTest)")
+    @Override
+    public void amqpShouldPublishDelegationUpdatedForSourceCalendarOnUpdateRight() throws Exception {
+        super.amqpShouldPublishDelegationUpdatedForSourceCalendarOnUpdateRight();
+    }
+
+    @Disabled("Fixed in Sabre 4_7 (com.linagora.dav.sabrev4_7.SabreV4CalDavDelegationTest)")
+    @Override
+    public void amqpShouldPublishDelegationUpdatedForSourceCalendarOnRevoke() throws Exception {
+        super.amqpShouldPublishDelegationUpdatedForSourceCalendarOnRevoke();
+    }
+
+    @Disabled("Fixed in Sabre 4_7 (com.linagora.dav.sabrev4_7.SabreV4CalDavDelegationTest)")
+    @Override
+    public void amqpShouldDedupDelegationUpdatedForSameSourceCalendarInSingleRequest() throws Exception {
+        super.amqpShouldDedupDelegationUpdatedForSameSourceCalendarInSingleRequest();
+    }
+
+    @Disabled("Fixed in Sabre 4_7 (com.linagora.dav.sabrev4_7.SabreV4CalDavDelegationTest)")
+    @Override
+    public void amqpShouldDedupDelegationUpdatedForSameSourceCalendarOnBulkRevoke() throws Exception {
+        super.amqpShouldDedupDelegationUpdatedForSameSourceCalendarOnBulkRevoke();
+    }
+
+    @Disabled("Fixed in Sabre 4_7 (com.linagora.dav.sabrev4_7.SabreV4CalDavDelegationTest)")
+    @Override
+    public void amqpShouldPublishDelegationUpdatedWhenRevokeOneOfTwoSharees() throws Exception {
+        super.amqpShouldPublishDelegationUpdatedWhenRevokeOneOfTwoSharees();
+    }
 }


### PR DESCRIPTION
resolve https://github.com/linagora/twake-calendar-integration-tests/issues/158

ref upstream: https://github.com/linagora/esn-sabre/pull/262

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bulk delegation: grant and revoke calendar access for multiple users in a single operation.

* **Tests**
  * Expanded delegation test coverage (grant/update/revoke, deduplication, multi-sharee scenarios).
  * Disabled several environment-specific delegation tests in one test variant pending platform update.

* **Chores**
  * Updated base image used for the Sabre 4.7 test/development environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->