### PR TITLE
ISSUE-162 Clones should not be created in attendee's calendars when organizer's part status is NEEDS_ACTION

### DIFF
--- a/Dockerfile.sabre4_7
+++ b/Dockerfile.sabre4_7
@@ -1,4 +1,4 @@
-ARG SABRE_4_7_IMAGE="linagora/esn-sabre:sabre-4_7_0-05-02-2026-1"
+ARG SABRE_4_7_IMAGE="linagora/esn-sabre:sabre-4_7_0-17-02-2026-1"
 
 FROM ${SABRE_4_7_IMAGE}
 

--- a/src/test/java/com/linagora/dav/contracts/CalDavContract.java
+++ b/src/test/java/com/linagora/dav/contracts/CalDavContract.java
@@ -1427,8 +1427,7 @@ public abstract class CalDavContract {
             """.formatted(eventUid, organizer.email(), attendee.email());
 
         // WHEN: The organizer creates the event
-        String calendarUri = "/calendars/" + organizer.id() + "/" + organizer.id() + "/" + eventUid + ".ics";
-        calDavClient.upsertCalendarEvent(organizer, URI.create(calendarUri), ics);
+        calDavClient.upsertCalendarEvent(organizer, eventUid, ics);
 
         // THEN: The event should exist in the organizer's calendar
         String organizerDefaultCalendarUri = "/calendars/" + organizer.id() + "/" + organizer.id();
@@ -1444,6 +1443,173 @@ public abstract class CalDavContract {
         });
 
         // AND: No clone should be created in the attendee's default calendar
+        String attendeeDefaultCalendarUri = "/calendars/" + attendee.id() + "/" + attendee.id();
+
+        Thread.sleep(1000);
+
+        List<JsonNode> attendeeEvents = calDavClient.reportCalendarEvents(attendee, attendeeDefaultCalendarUri,
+                Instant.parse("2024-09-01T00:00:00Z"),
+                Instant.parse("2026-11-01T00:00:00Z"))
+            .collectList()
+            .block();
+
+        assertThat(attendeeEvents)
+            .filteredOn(node -> node.toString().contains(eventUid))
+            .isEmpty();
+    }
+
+    @Disabled("https://github.com/linagora/esn-sabre/issues/268")
+    @ParameterizedTest
+    @ValueSource(strings = {"ACCEPTED", "TENTATIVE"})
+    void cloneShouldBeCreatedInAttendeeCalendarWhenOrganizerAcceptMeetingProposition(String partStat) throws InterruptedException {
+        OpenPaasUser organizer = dockerExtension().newTestUser();
+        OpenPaasUser attendee = dockerExtension().newTestUser();
+
+        // GIVEN: An organizer creates an event with PARTSTAT=NEEDS-ACTION and X-PUBLICLY-CREATED:true
+        String eventUid = "event-" + UUID.randomUUID();
+
+        String ics = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Example Corp.//CalDAV Client//EN
+            CALSCALE:GREGORIAN
+            BEGIN:VEVENT
+            UID:{eventUid}
+            DTSTAMP:20251008T080000Z
+            DTSTART:20251009T090000Z
+            DTEND:20251009T100000Z
+            SUMMARY:Publicly created meeting
+            ORGANIZER;CN=Organizer:mailto:{organizerEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:{organizerEmail}
+            ATTENDEE;CN=Attendee;PARTSTAT=NEEDS-ACTION:mailto:{attendeeEmail}
+            X-PUBLICLY-CREATED:true
+            END:VEVENT
+            END:VCALENDAR
+            """.replace("{eventUid}", eventUid)
+            .replace("{organizerEmail}", organizer.email())
+            .replace("{attendeeEmail}", attendee.email());
+
+        calDavClient.upsertCalendarEvent(organizer, eventUid, ics);
+
+        // Check if event exist in the organizer's calendar
+        String organizerDefaultCalendarUri = "/calendars/" + organizer.id() + "/" + organizer.id();
+        awaitAtMost.untilAsserted(() -> {
+            List<JsonNode> organizerEvents = calDavClient.reportCalendarEvents(organizer, organizerDefaultCalendarUri,
+                    Instant.parse("2024-09-01T00:00:00Z"),
+                    Instant.parse("2026-11-01T00:00:00Z"))
+                .collectList()
+                .block();
+
+            assertThat(organizerEvents)
+                .anySatisfy(node -> assertThat(node.toString()).contains(eventUid));
+        });
+
+        String updatedIcs = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Example Corp.//CalDAV Client//EN
+            CALSCALE:GREGORIAN
+            BEGIN:VEVENT
+            UID:{eventUid}
+            DTSTAMP:20251008T080000Z
+            DTSTART:20251009T090000Z
+            DTEND:20251009T100000Z
+            SUMMARY:Publicly created meeting
+            ORGANIZER;CN=Organizer:mailto:{organizerEmail}
+            ATTENDEE;PARTSTAT={partStat};RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:{organizerEmail}
+            ATTENDEE;CN=Attendee;PARTSTAT=NEEDS-ACTION:mailto:{attendeeEmail}
+            X-PUBLICLY-CREATED:true
+            END:VEVENT
+            END:VCALENDAR
+            """.replace("{eventUid}", eventUid)
+            .replace("{organizerEmail}", organizer.email())
+            .replace("{attendeeEmail}", attendee.email())
+            .replace("{partStat}", partStat);
+
+        // WHEN: The organizer accept the event
+        calDavClient.upsertCalendarEvent(organizer, eventUid, updatedIcs);
+
+        // THEN: Clone should be created in the attendee's default calendar
+        String attendeeDefaultCalendarUri = "/calendars/" + attendee.id() + "/" + attendee.id();
+
+        awaitAtMost.untilAsserted(() -> {
+            List<JsonNode> attendeeEvents = calDavClient.reportCalendarEvents(attendee, attendeeDefaultCalendarUri,
+                    Instant.parse("2024-09-01T00:00:00Z"),
+                    Instant.parse("2026-11-01T00:00:00Z"))
+                .collectList()
+                .block();
+
+            assertThat(attendeeEvents)
+                .anySatisfy(node -> assertThat(node.toString()).contains(eventUid));
+        });
+    }
+
+    @Disabled("https://github.com/linagora/esn-sabre/issues/269")
+    @Test
+    void cloneShouldNotBeCreatedInAttendeeCalendarWhenOrganizerDeclineMeetingProposition() throws InterruptedException {
+        OpenPaasUser organizer = dockerExtension().newTestUser();
+        OpenPaasUser attendee = dockerExtension().newTestUser();
+
+        // GIVEN: An organizer creates an event with PARTSTAT=NEEDS-ACTION and X-PUBLICLY-CREATED:true
+        String eventUid = "event-" + UUID.randomUUID();
+
+        String ics = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Example Corp.//CalDAV Client//EN
+            CALSCALE:GREGORIAN
+            BEGIN:VEVENT
+            UID:%s
+            DTSTAMP:20251008T080000Z
+            DTSTART:20251009T090000Z
+            DTEND:20251009T100000Z
+            SUMMARY:Publicly created meeting
+            ORGANIZER;CN=Organizer:mailto:%s
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:{organizerEmail}
+            ATTENDEE;CN=Attendee;PARTSTAT=NEEDS-ACTION:mailto:%s
+            X-PUBLICLY-CREATED:true
+            END:VEVENT
+            END:VCALENDAR
+            """.formatted(eventUid, organizer.email(), attendee.email());
+
+        calDavClient.upsertCalendarEvent(organizer, eventUid, ics);
+
+        // Check if event exist in the organizer's calendar
+        String organizerDefaultCalendarUri = "/calendars/" + organizer.id() + "/" + organizer.id();
+        awaitAtMost.untilAsserted(() -> {
+            List<JsonNode> organizerEvents = calDavClient.reportCalendarEvents(organizer, organizerDefaultCalendarUri,
+                    Instant.parse("2024-09-01T00:00:00Z"),
+                    Instant.parse("2026-11-01T00:00:00Z"))
+                .collectList()
+                .block();
+
+            assertThat(organizerEvents)
+                .anySatisfy(node -> assertThat(node.toString()).contains(eventUid));
+        });
+
+        String updatedIcs = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Example Corp.//CalDAV Client//EN
+            CALSCALE:GREGORIAN
+            BEGIN:VEVENT
+            UID:%s
+            DTSTAMP:20251008T080000Z
+            DTSTART:20251009T090000Z
+            DTEND:20251009T100000Z
+            SUMMARY:Publicly created meeting
+            ORGANIZER;CN=Organizer:mailto:%s
+            ATTENDEE;PARTSTAT=DECLINED;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:{organizerEmail}
+            ATTENDEE;CN=Attendee;PARTSTAT=NEEDS-ACTION:mailto:%s
+            X-PUBLICLY-CREATED:true
+            END:VEVENT
+            END:VCALENDAR
+            """.formatted(eventUid, organizer.email(), attendee.email());
+
+        // WHEN: The organizer accept the event
+        calDavClient.upsertCalendarEvent(organizer, eventUid, updatedIcs);
+
+        // THEN: No clone should be created in the attendee's default calendar
         String attendeeDefaultCalendarUri = "/calendars/" + attendee.id() + "/" + attendee.id();
 
         Thread.sleep(1000);

--- a/src/test/java/com/linagora/dav/contracts/CalDavContract.java
+++ b/src/test/java/com/linagora/dav/contracts/CalDavContract.java
@@ -1399,7 +1399,6 @@ public abstract class CalDavContract {
         });
     }
 
-    @Disabled("https://github.com/linagora/esn-sabre/issues/267")
     @Test
     void cloneShouldNotBeCreatedInAttendeeCalendarWhenOrganizerPartStatIsNeedsActionAndPubliclyCreated() throws InterruptedException {
         OpenPaasUser organizer = dockerExtension().newTestUser();

--- a/src/test/java/com/linagora/dav/contracts/CalDavContract.java
+++ b/src/test/java/com/linagora/dav/contracts/CalDavContract.java
@@ -1400,7 +1400,7 @@ public abstract class CalDavContract {
     }
 
     @Test
-    void cloneShouldNotBeCreatedInAttendeeCalendarWhenOrganizerPartStatIsNeedsActionAndPubliclyCreated() throws InterruptedException {
+    protected void cloneShouldNotBeCreatedInAttendeeCalendarWhenOrganizerPartStatIsNeedsActionAndPubliclyCreated() throws InterruptedException {
         OpenPaasUser organizer = dockerExtension().newTestUser();
         OpenPaasUser attendee = dockerExtension().newTestUser();
 
@@ -1419,12 +1419,12 @@ public abstract class CalDavContract {
             DTEND:20251009T100000Z
             SUMMARY:Publicly created meeting
             ORGANIZER;CN=Organizer:mailto:%s
-            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:{organizerEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:%s
             ATTENDEE;CN=Attendee;PARTSTAT=NEEDS-ACTION:mailto:%s
             X-PUBLICLY-CREATED:true
             END:VEVENT
             END:VCALENDAR
-            """.formatted(eventUid, organizer.email(), attendee.email());
+            """.formatted(eventUid, organizer.email(), organizer.email(), attendee.email());
 
         // WHEN: The organizer creates the event
         calDavClient.upsertCalendarEvent(organizer, eventUid, ics);
@@ -1458,10 +1458,9 @@ public abstract class CalDavContract {
             .isEmpty();
     }
 
-    @Disabled("https://github.com/linagora/esn-sabre/issues/268")
     @ParameterizedTest
     @ValueSource(strings = {"ACCEPTED", "TENTATIVE"})
-    void cloneShouldBeCreatedInAttendeeCalendarWhenOrganizerAcceptMeetingProposition(String partStat) throws InterruptedException {
+    protected void cloneShouldBeCreatedInAttendeeCalendarWhenOrganizerAcceptMeetingProposition(String partStat) {
         OpenPaasUser organizer = dockerExtension().newTestUser();
         OpenPaasUser attendee = dockerExtension().newTestUser();
 
@@ -1544,9 +1543,8 @@ public abstract class CalDavContract {
         });
     }
 
-    @Disabled("https://github.com/linagora/esn-sabre/issues/269")
     @Test
-    void cloneShouldNotBeCreatedInAttendeeCalendarWhenOrganizerDeclineMeetingProposition() throws InterruptedException {
+    protected void cloneShouldNotBeCreatedInAttendeeCalendarWhenOrganizerDeclineMeetingProposition() throws InterruptedException {
         OpenPaasUser organizer = dockerExtension().newTestUser();
         OpenPaasUser attendee = dockerExtension().newTestUser();
 
@@ -1601,12 +1599,12 @@ public abstract class CalDavContract {
             DTEND:20251009T100000Z
             SUMMARY:Publicly created meeting
             ORGANIZER;CN=Organizer:mailto:%s
-            ATTENDEE;PARTSTAT=DECLINED;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:{organizerEmail}
+            ATTENDEE;PARTSTAT=DECLINED;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:%s
             ATTENDEE;CN=Attendee;PARTSTAT=NEEDS-ACTION:mailto:%s
             X-PUBLICLY-CREATED:true
             END:VEVENT
             END:VCALENDAR
-            """.formatted(eventUid, organizer.email(), attendee.email());
+            """.formatted(eventUid, organizer.email(), organizer.email(), attendee.email());
 
         // WHEN: The organizer decline the event
         calDavClient.upsertCalendarEvent(organizer, eventUid, updatedIcs);

--- a/src/test/java/com/linagora/dav/contracts/CalDavContract.java
+++ b/src/test/java/com/linagora/dav/contracts/CalDavContract.java
@@ -1559,18 +1559,20 @@ public abstract class CalDavContract {
             PRODID:-//Example Corp.//CalDAV Client//EN
             CALSCALE:GREGORIAN
             BEGIN:VEVENT
-            UID:%s
+            UID:{eventUid}
             DTSTAMP:20251008T080000Z
             DTSTART:20251009T090000Z
             DTEND:20251009T100000Z
             SUMMARY:Publicly created meeting
-            ORGANIZER;CN=Organizer:mailto:%s
+            ORGANIZER;CN=Organizer:mailto:{organizerEmail}
             ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:{organizerEmail}
-            ATTENDEE;CN=Attendee;PARTSTAT=NEEDS-ACTION:mailto:%s
+            ATTENDEE;CN=Attendee;PARTSTAT=NEEDS-ACTION:mailto:{attendeeEmail}
             X-PUBLICLY-CREATED:true
             END:VEVENT
             END:VCALENDAR
-            """.formatted(eventUid, organizer.email(), attendee.email());
+            """.replace("{eventUid}", eventUid)
+            .replace("{organizerEmail}", organizer.email())
+            .replace("{attendeeEmail}", attendee.email());
 
         calDavClient.upsertCalendarEvent(organizer, eventUid, ics);
 
@@ -1606,7 +1608,7 @@ public abstract class CalDavContract {
             END:VCALENDAR
             """.formatted(eventUid, organizer.email(), attendee.email());
 
-        // WHEN: The organizer accept the event
+        // WHEN: The organizer decline the event
         calDavClient.upsertCalendarEvent(organizer, eventUid, updatedIcs);
 
         // THEN: No clone should be created in the attendee's default calendar

--- a/src/test/java/com/linagora/dav/sabrev4/SabreV4CalDavTest.java
+++ b/src/test/java/com/linagora/dav/sabrev4/SabreV4CalDavTest.java
@@ -18,6 +18,7 @@
 
 package com.linagora.dav.sabrev4;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linagora.dav.DockerTwakeCalendarExtensionV4;
@@ -30,5 +31,20 @@ class SabreV4CalDavTest extends CalDavContract {
     @Override
     public DockerTwakeCalendarExtensionV4 dockerExtension() {
         return dockerExtension;
+    }
+
+    @Override
+    @Disabled("Supported only on Sabre 4.7 as part of the new spec")
+    protected void cloneShouldNotBeCreatedInAttendeeCalendarWhenOrganizerPartStatIsNeedsActionAndPubliclyCreated() {
+    }
+
+    @Override
+    @Disabled("Supported only on Sabre 4.7 as part of the new spec")
+    protected void cloneShouldBeCreatedInAttendeeCalendarWhenOrganizerAcceptMeetingProposition(String partStat) {
+    }
+
+    @Override
+    @Disabled("Supported only on Sabre 4.7 as part of the new spec")
+    protected void cloneShouldNotBeCreatedInAttendeeCalendarWhenOrganizerDeclineMeetingProposition() {
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for attendee calendar cloning and notification behavior across PARTSTAT transitions (needs-action, accepted/tentative, declined), public-creation flag, recurring events, and internal vs. external attendees.
  * Added many new test cases—several duplicated across the suite—and numerous tests annotated as disabled.
  * Test-only changes; no impact on production behavior or user-visible features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->