### PR TITLE
Update tests in EmailAMQPMessageContract for public agenda feature

### DIFF
--- a/src/test/java/com/linagora/dav/sabrev4/SabreV4EmailAMQPMessageTest.java
+++ b/src/test/java/com/linagora/dav/sabrev4/SabreV4EmailAMQPMessageTest.java
@@ -40,4 +40,14 @@ public class SabreV4EmailAMQPMessageTest extends EmailAMQPMessageContract {
     public void shouldReceiveNotificationEmailMessageOnEventCreationWith1DVALARM() {
         super.shouldReceiveNotificationEmailMessageOnEventCreationWith1DVALARM();
     }
+
+    @Override
+    @Disabled("Supported only on Sabre 4.7 as part of the new spec")
+    protected void shouldNotReceiveNotificationEmailMessageWhenOrganizerPartStatIsNeedsActionAndPubliclyCreatedWithInternalAttendee() {
+    }
+
+    @Override
+    @Disabled("Supported only on Sabre 4.7 as part of the new spec")
+    protected void shouldNotReceiveNotificationEmailMessageWhenOrganizerPartStatIsNeedsActionAndPubliclyCreatedWithExternalAttendee() {
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded notification message tests to cover declined participant status scenarios.
  * Standardized test names and wording to reference "notification email message" for clarity.
  * Reactivated several previously-disabled tests (now hidden from public test API).
  * Disabled two vendor-specific tests to preserve compatibility with that server version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->