### PR TITLE
Adopt sabre-4_7_0-24-02-2026

### DIFF
--- a/Dockerfile.sabre4_7
+++ b/Dockerfile.sabre4_7
@@ -1,4 +1,4 @@
-ARG SABRE_4_7_IMAGE="linagora/esn-sabre:sabre-4_7_0-17-02-2026-1"
+ARG SABRE_4_7_IMAGE="linagora/esn-sabre:sabre-4_7_0-24-02-2026"
 
 FROM ${SABRE_4_7_IMAGE}
 


### PR DESCRIPTION
Image `linagora/esn-sabre:sabre-4_7_0-17-02-2026-1` does not exist
CI build image from tag failed before https://james-jenkins.lin-saas.com/job/ESN%20Sabre%20build/view/tags/job/sabre-4_7_0-17-02-2026-1/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a containerized service image to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->