### PR TITLE
ISSUE-162 [Public Agenda] enable EmailAMQPMessageContract and stabilize async assertions

### DIFF
--- a/Dockerfile.sabre4_7
+++ b/Dockerfile.sabre4_7
@@ -1,4 +1,4 @@
-ARG SABRE_4_7_IMAGE="linagora/esn-sabre:sabre-4_7_0-24-02-2026"
+ARG SABRE_4_7_IMAGE="linagora/esn-sabre:sabre-4_7_0-03-03-2026-2"
 
 FROM ${SABRE_4_7_IMAGE}
 

--- a/src/test/java/com/linagora/dav/contracts/EmailAMQPMessageContract.java
+++ b/src/test/java/com/linagora/dav/contracts/EmailAMQPMessageContract.java
@@ -1270,6 +1270,79 @@ public abstract class EmailAMQPMessageContract {
     }
 
     @Test
+    protected void shouldSendNotificationEmailWhenAcceptedAfterSetRecurringPubliclyCreated() {
+        OpenPaasUser organizer = dockerExtension().newTestUser();
+        OpenPaasUser attendee = dockerExtension().newTestUser();
+        String eventUid = UUID.randomUUID().toString();
+        String recurrenceRule = "RRULE:FREQ=DAILY;COUNT=3";
+
+        String initialCalendarData = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Sabre//Sabre VObject 4.1.3//EN
+            CALSCALE:GREGORIAN
+            BEGIN:VEVENT
+            UID:{eventUid}
+            DTSTAMP:30250411T022032Z
+            SEQUENCE:1
+            DTSTART:30250411T100000Z
+            DTEND:30250411T110000Z
+            SUMMARY:Publicly created recurring meeting
+            LOCATION:Twake Meeting Room
+            DESCRIPTION:This is a publicly created recurring meeting.
+            ORGANIZER;CN=Organizer:mailto:{organizerEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:{organizerEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;CN=Attendee:mailto:{attendeeEmail}
+            {xPubliclyCreated}
+            END:VEVENT
+            END:VCALENDAR
+            """.replace("{eventUid}", eventUid)
+            .replace("{organizerEmail}", organizer.email())
+            .replace("{attendeeEmail}", attendee.email())
+            .replace("{xPubliclyCreated}", X_PUBLICLY_CREATED_HEADER);
+
+        calDavClient.upsertCalendarEvent(organizer, eventUid, initialCalendarData);
+
+        calmlyAwait
+            .during(1, TimeUnit.SECONDS)
+            .untilAsserted(() -> assertThat(dockerExtension().getChannel().basicGet(QUEUE_NAME, true)).isNull());
+
+        String recurringCalendarData = initialCalendarData
+            .replace("SEQUENCE:1", "SEQUENCE:2")
+            .replace("DTEND:30250411T110000Z", "DTEND:30250411T110000Z\n" + recurrenceRule);
+
+        calDavClient.upsertCalendarEvent(organizer, eventUid, recurringCalendarData);
+
+        calmlyAwait
+            .during(1, TimeUnit.SECONDS)
+            .untilAsserted(() -> assertThat(dockerExtension().getChannel().basicGet(QUEUE_NAME, true)).isNull());
+
+        String acceptedCalendarData = recurringCalendarData
+            .replace("SEQUENCE:2", "SEQUENCE:3")
+            .replace("ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:" + organizer.email(),
+                "ATTENDEE;PARTSTAT=ACCEPTED;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:" + organizer.email());
+
+        calDavClient.upsertCalendarEvent(organizer, eventUid, acceptedCalendarData);
+
+        String actual = new String(getMessageFromQueue(), StandardCharsets.UTF_8);
+
+        assertThatJson(actual)
+            .whenIgnoringPaths("event", "calendarURI", "eventPath")
+            .isEqualTo("""
+                {
+                  "senderEmail": "{organizerEmail}",
+                  "recipientEmail": "{attendeeEmail}",
+                  "method": "REQUEST",
+                  "event": "ignored",
+                  "notify": true,
+                  "calendarURI": "ignored",
+                  "eventPath": "ignored"
+                }
+                """.replace("{organizerEmail}", organizer.email())
+                .replace("{attendeeEmail}", attendee.email()));
+    }
+
+    @Test
     protected void shouldNotSendNotificationEmailWhenOrganizerPartStatUpdatedFromNeedsActionToDeclinedWithInternalAttendee() throws InterruptedException, IOException {
         OpenPaasUser organizer = dockerExtension().newTestUser();
         OpenPaasUser attendee = dockerExtension().newTestUser();

--- a/src/test/java/com/linagora/dav/sabrev4/SabreV4EmailAMQPMessageTest.java
+++ b/src/test/java/com/linagora/dav/sabrev4/SabreV4EmailAMQPMessageTest.java
@@ -18,6 +18,8 @@
 
 package com.linagora.dav.sabrev4;
 
+import java.io.IOException;
+
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -39,5 +41,41 @@ public class SabreV4EmailAMQPMessageTest extends EmailAMQPMessageContract {
     @Override
     public void shouldReceiveNotificationEmailMessageOnEventCreationWith1DVALARM() {
         super.shouldReceiveNotificationEmailMessageOnEventCreationWith1DVALARM();
+    }
+
+    @Disabled("Only supported in Sabre 4.7+")
+    @Override
+    public void shouldNotSendNotificationEmailWhenOrganizerPartStatIsNeedsActionAndPubliclyCreatedWithInternalAttendee() throws IOException, InterruptedException {
+        super.shouldNotSendNotificationEmailWhenOrganizerPartStatIsNeedsActionAndPubliclyCreatedWithInternalAttendee();
+    }
+
+    @Disabled("Only supported in Sabre 4.7+")
+    @Override
+    public void shouldNotSendNotificationEmailWhenOrganizerPartStatIsNeedsActionAndPubliclyCreatedWithExternalAttendee() {
+        super.shouldNotSendNotificationEmailWhenOrganizerPartStatIsNeedsActionAndPubliclyCreatedWithExternalAttendee();
+    }
+
+    @Disabled("Only supported in Sabre 4.7+")
+    @Override
+    public void shouldSendNotificationEmailWhenOrganizerPartStatUpdatedFromNeedsActionToAcceptedWithInternalAttendee(String partStat) {
+        super.shouldSendNotificationEmailWhenOrganizerPartStatUpdatedFromNeedsActionToAcceptedWithInternalAttendee(partStat);
+    }
+
+    @Disabled("Only supported in Sabre 4.7+")
+    @Override
+    public void shouldSendNotificationEmailWhenOrganizerPartStatUpdatedFromNeedsActionToAcceptedWithExternalAttendee(String partStat) {
+        super.shouldSendNotificationEmailWhenOrganizerPartStatUpdatedFromNeedsActionToAcceptedWithExternalAttendee(partStat);
+    }
+
+    @Disabled("Only supported in Sabre 4.7+")
+    @Override
+    public void shouldNotSendNotificationEmailWhenOrganizerPartStatUpdatedFromNeedsActionToDeclinedWithInternalAttendee() throws InterruptedException, IOException {
+        super.shouldNotSendNotificationEmailWhenOrganizerPartStatUpdatedFromNeedsActionToDeclinedWithInternalAttendee();
+    }
+
+    @Disabled("Only supported in Sabre 4.7+")
+    @Override
+    public void shouldNotSendNotificationEmailWhenOrganizerPartStatUpdatedFromNeedsActionToDeclinedWithExternalAttendee() throws InterruptedException, IOException {
+        super.shouldNotSendNotificationEmailWhenOrganizerPartStatUpdatedFromNeedsActionToDeclinedWithExternalAttendee();
     }
 }

--- a/src/test/java/com/linagora/dav/sabrev4/SabreV4EmailAMQPMessageTest.java
+++ b/src/test/java/com/linagora/dav/sabrev4/SabreV4EmailAMQPMessageTest.java
@@ -69,6 +69,12 @@ public class SabreV4EmailAMQPMessageTest extends EmailAMQPMessageContract {
 
     @Disabled("Only supported in Sabre 4.7+")
     @Override
+    public void shouldSendNotificationEmailWhenAcceptedAfterSetRecurringPubliclyCreated() {
+        super.shouldSendNotificationEmailWhenAcceptedAfterSetRecurringPubliclyCreated();
+    }
+
+    @Disabled("Only supported in Sabre 4.7+")
+    @Override
     public void shouldNotSendNotificationEmailWhenOrganizerPartStatUpdatedFromNeedsActionToDeclinedWithInternalAttendee() throws InterruptedException, IOException {
         super.shouldNotSendNotificationEmailWhenOrganizerPartStatUpdatedFromNeedsActionToDeclinedWithInternalAttendee();
     }


### PR DESCRIPTION
for upstream: 
- https://github.com/linagora/esn-sabre/pull/280

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability with Awaitility-based waiting for queue/state checks.
  * Enhanced JSON assertions that ignore non-deterministic fields.
  * Expanded coverage for publicly-created header handling and attendee PARTSTAT scenarios (including recurring events and acceptance flows).
  * Re-enabled many tests; several platform-specific tests are disabled for Sabre 4.7+.
* **Chores**
  * Updated Sabre 4.7 base image tag used in CI/build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->