### PR TITLE
ISSUE-271 add CalDAV test when deleting organizer-less event

### DIFF
--- a/Dockerfile.sabre4_7
+++ b/Dockerfile.sabre4_7
@@ -1,4 +1,4 @@
-ARG SABRE_4_7_IMAGE="linagora/esn-sabre:sabre-4_7_0-24-02-2026"
+ARG SABRE_4_7_IMAGE="linagora/esn-sabre:sabre-4_7_0-03-03-2026"
 
 FROM ${SABRE_4_7_IMAGE}
 

--- a/src/test/java/com/linagora/dav/contracts/CalDavContract.java
+++ b/src/test/java/com/linagora/dav/contracts/CalDavContract.java
@@ -555,7 +555,7 @@ public abstract class CalDavContract {
     }
 
     @Test
-    void deleteShouldNotCrashForEventWithoutOrganizer() {
+    protected void deleteShouldNotCrashForEventWithoutOrganizer() {
         OpenPaasUser testUser = dockerExtension().newTestUser();
 
         int createStatus = executeNoContent(dockerExtension().davHttpClient()

--- a/src/test/java/com/linagora/dav/contracts/CalDavContract.java
+++ b/src/test/java/com/linagora/dav/contracts/CalDavContract.java
@@ -555,6 +555,32 @@ public abstract class CalDavContract {
     }
 
     @Test
+    void deleteShouldNotCrashForEventWithoutOrganizer() {
+        OpenPaasUser testUser = dockerExtension().newTestUser();
+
+        int createStatus = executeNoContent(dockerExtension().davHttpClient()
+            .headers(headers -> testUser.impersonatedBasicAuth(headers).add("Content-Type", "text/calendar ; charset=utf-8"))
+            .put()
+            .uri("/calendars/" + testUser.id() + "/" + testUser.id() + "/no-organizer.ics")
+            .send(body(ICS_3_B.replace("ORGANIZER;CN=Julie VERRIER:mailto:[REPLACE]", "")
+                .replace("mailto:apujol@linagora.com", "mailto:" + testUser.email()))));
+
+        int deleteStatus = executeNoContent(dockerExtension().davHttpClient()
+            .headers(testUser::impersonatedBasicAuth)
+            .delete()
+            .uri("/calendars/" + testUser.id()  + "/" + testUser.id() + "/no-organizer.ics"));
+
+        int getAfterDeleteStatus = executeNoContent(dockerExtension().davHttpClient()
+            .headers(headers -> testUser.impersonatedBasicAuth(headers).add("Accept", "text/calendar"))
+            .get()
+            .uri("/calendars/" + testUser.id() + "/" + testUser.id() + "/no-organizer.ics"));
+
+        assertThat(createStatus).isEqualTo(201);
+        assertThat(deleteStatus).isEqualTo(204);
+        assertThat(getAfterDeleteStatus).isEqualTo(404);
+    }
+
+    @Test
     void putShouldUpdateData() {
         OpenPaasUser testUser = dockerExtension().newTestUser();
 

--- a/src/test/java/com/linagora/dav/sabrev4/SabreV4CalDavTest.java
+++ b/src/test/java/com/linagora/dav/sabrev4/SabreV4CalDavTest.java
@@ -47,4 +47,9 @@ class SabreV4CalDavTest extends CalDavContract {
     @Disabled("Supported only on Sabre 4.7 as part of the new spec")
     protected void cloneShouldNotBeCreatedInAttendeeCalendarWhenOrganizerDeclineMeetingProposition() {
     }
+
+    @Override
+    @Disabled("Fixed on Sabre 4.7")
+    protected void deleteShouldNotCrashForEventWithoutOrganizer() {
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of calendar event deletion when an event has no organizer.

* **Tests**
  * Added a test to verify deletion of events without organizers; a platform-specific variant is present but disabled where not applicable.

* **Chores**
  * Updated a container image reference used for test environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->