### PR TITLE
Add runtime toggle for AMQP_SCHEDULING_ENABLED in integration tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,23 +12,43 @@ pipeline {
     }
 
     stages {
-        stage('Compile and Test') {
+        stage('Pre-build') {
             steps {
                 sh 'sh pre-build.sh'
+            }
+        }
+
+        stage('Test default config') {
+            steps {
                 sh 'mvn clean install -Dapi.version=1.43'
-                sh 'mvn test -Damqp.scheduling.enabled=true -Dapi.version=1.43'
             }
             post {
                 always {
                     junit(testResults: '**/surefire-reports/*.xml', allowEmptyResults: false)
                 }
                 failure {
-                    archiveArtifacts artifacts: '**/target/test-run.log' , fingerprint: true
-                    archiveArtifacts artifacts: '**/surefire-reports/*' , fingerprint: true
+                    archiveArtifacts artifacts: '**/target/test-run.log', fingerprint: true
+                    archiveArtifacts artifacts: '**/surefire-reports/*', fingerprint: true
+                }
+            }
+        }
+
+        stage('Test with amqp scheduling enabled') {
+            steps {
+                sh 'mvn test -Damqp.scheduling.enabled=true -Dapi.version=1.43 -Dsurefire.reportsDirectory=target/surefire-reports-amqp-scheduling'
+            }
+            post {
+                always {
+                    junit(testResults: 'target/surefire-reports-amqp-scheduling/*.xml', allowEmptyResults: false)
+                }
+                failure {
+                    archiveArtifacts artifacts: '**/target/test-run.log', fingerprint: true
+                    archiveArtifacts artifacts: 'target/surefire-reports-amqp-scheduling/*', fingerprint: true
                 }
             }
         }
     }
+
     post {
         always {
             deleteDir() /* clean up our workspace */

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,7 @@ pipeline {
             steps {
                 sh 'sh pre-build.sh'
                 sh 'mvn clean install -Dapi.version=1.43'
+                sh 'mvn test -Damqp.scheduling.enabled=true -Dapi.version=1.43'
             }
             post {
                 always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,15 +35,15 @@ pipeline {
 
         stage('Test with amqp scheduling enabled') {
             steps {
-                sh 'mvn test -Damqp.scheduling.enabled=true -Dapi.version=1.43 -Dsurefire.reportsDirectory=target/surefire-reports-amqp-scheduling'
+                sh 'mvn test -Damqp.scheduling.enabled=true -Dapi.version=1.43 -Dsurefire.reportNameSuffix=amqp-scheduling'
             }
             post {
                 always {
-                    junit(testResults: 'target/surefire-reports-amqp-scheduling/*.xml', allowEmptyResults: false)
+                    junit(testResults: '**/surefire-reports/*-amqp-scheduling.xml', allowEmptyResults: false)
                 }
                 failure {
                     archiveArtifacts artifacts: '**/target/test-run.log', fingerprint: true
-                    archiveArtifacts artifacts: 'target/surefire-reports-amqp-scheduling/*', fingerprint: true
+                    archiveArtifacts artifacts: '**/surefire-reports/*-amqp-scheduling*', fingerprint: true
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ mvn clean install
 mvn test
 
 # Enable
-mvn test -Pamqp-scheduling-on
+mvn test -Damqp.scheduling.enabled=true
 ```

--- a/README.md
+++ b/README.md
@@ -5,3 +5,13 @@ Running the tests:
 ```
 mvn clean install
 ```
+
+## AMQP scheduling (`esn-sabre`):
+
+```
+# Default disable: env AMQP_SCHEDULING_ENABLED = false
+mvn test
+
+# Enable
+mvn test -Pamqp-scheduling-on
+```

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <james.groupId>org.apache.james</james.groupId>
         <james.baseVersion>3.10.0-SNAPSHOT</james.baseVersion>
         <jackson.version>2.18.2</jackson.version>
+        <amqp.scheduling.enabled>false</amqp.scheduling.enabled>
     </properties>
 
     <dependencies>
@@ -175,12 +176,25 @@
                     <argLine>-Xms512m -Xmx2048m</argLine>
                     <reuseForks>true</reuseForks>
                     <forkCount>1</forkCount>
+                    <systemPropertyVariables>
+                        <!-- Pass value to tests so esn-sabre runs with AMQP_SCHEDULING_ENABLED environment variable -->
+                        <amqp.scheduling.enabled>${amqp.scheduling.enabled}</amqp.scheduling.enabled>
+                    </systemPropertyVariables>
                     <!-- Fail tests longer than 40 minutes, prevent form random locking tests -->
                     <forkedProcessTimeoutInSeconds>2400</forkedProcessTimeoutInSeconds>
                 </configuration>
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>amqp-scheduling-on</id>
+            <properties>
+                <amqp.scheduling.enabled>true</amqp.scheduling.enabled>
+            </properties>
+        </profile>
+    </profiles>
 
     <!-- Remove this following block when adapt a concrete James release version -->
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,6 @@
         <james.groupId>org.apache.james</james.groupId>
         <james.baseVersion>3.10.0-SNAPSHOT</james.baseVersion>
         <jackson.version>2.18.2</jackson.version>
-        <amqp.scheduling.enabled>false</amqp.scheduling.enabled>
     </properties>
 
     <dependencies>
@@ -176,25 +175,12 @@
                     <argLine>-Xms512m -Xmx2048m</argLine>
                     <reuseForks>true</reuseForks>
                     <forkCount>1</forkCount>
-                    <systemPropertyVariables>
-                        <!-- Pass value to tests so esn-sabre runs with AMQP_SCHEDULING_ENABLED environment variable -->
-                        <amqp.scheduling.enabled>${amqp.scheduling.enabled}</amqp.scheduling.enabled>
-                    </systemPropertyVariables>
                     <!-- Fail tests longer than 40 minutes, prevent form random locking tests -->
                     <forkedProcessTimeoutInSeconds>2400</forkedProcessTimeoutInSeconds>
                 </configuration>
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>amqp-scheduling-on</id>
-            <properties>
-                <amqp.scheduling.enabled>true</amqp.scheduling.enabled>
-            </properties>
-        </profile>
-    </profiles>
 
     <!-- Remove this following block when adapt a concrete James release version -->
     <repositories>

--- a/src/test/java/com/linagora/dav/DockerTwakeCalendarSetup.java
+++ b/src/test/java/com/linagora/dav/DockerTwakeCalendarSetup.java
@@ -25,10 +25,16 @@ import java.time.Duration;
 
 import org.apache.http.client.utils.URIBuilder;
 import org.junit.platform.commons.util.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.ComposeContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 public class DockerTwakeCalendarSetup {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DockerTwakeCalendarSetup.class);
+    private static final String AMQP_SCHEDULING_ENABLED_PROPERTY = "amqp.scheduling.enabled";
+    private static final String AMQP_SCHEDULING_ENABLED_DEFAULT = "false";
+
     public enum DockerService {
         CALENDAR_SIDE("twake-calendar-side-service", 8080),
         CALENDAR_SIDE_ADMIN("twake-calendar-side-service", 8000),
@@ -64,6 +70,8 @@ public class DockerTwakeCalendarSetup {
     private TwakeCalendarProvisioningService twakeCalendarProvisioningService;
 
     public DockerTwakeCalendarSetup(String sabreVersion) {
+        String amqpSchedulingEnabled = System.getProperty(AMQP_SCHEDULING_ENABLED_PROPERTY, AMQP_SCHEDULING_ENABLED_DEFAULT);
+        LOGGER.info("Test config: {}={}", AMQP_SCHEDULING_ENABLED_PROPERTY, amqpSchedulingEnabled);
         try {
             environment = new ComposeContainer(
                 new File(DockerTwakeCalendarSetup.class.getResource("/docker-twake-calendar-setup.yml").toURI()))
@@ -79,6 +87,7 @@ public class DockerTwakeCalendarSetup {
                 .waitingFor(DockerService.CALENDAR_SIDE.serviceName(), Wait.forLogMessage(".*StartUpChecks all succeeded.*", 1)
                     .withStartupTimeout(Duration.ofMinutes(10)))
                 .withEnv("SABRE_DAV_IMAGE", sabreVersion)
+                .withEnv("AMQP_SCHEDULING_ENABLED", amqpSchedulingEnabled)
                 .withLogConsumer(DockerService.SABRE_DAV.serviceName(), log -> System.out.print("sabre_dav " + log.getUtf8String()))
                 .withLogConsumer(DockerService.CALENDAR_SIDE.serviceName(), log -> System.out.print("twake-calendar-side-service " + log.getUtf8String()));
         } catch (URISyntaxException e) {

--- a/src/test/resources/docker-twake-calendar-setup.yml
+++ b/src/test/resources/docker-twake-calendar-setup.yml
@@ -94,5 +94,6 @@ services:
       - LDAP_USERNAME_MODE=username
       - LOG_TRACE=true
       - SABRE_IMPERSONATION_ENABLED=true
+      - AMQP_SCHEDULING_ENABLED=${AMQP_SCHEDULING_ENABLED}
     networks:
       - emaily


### PR DESCRIPTION
ref https://github.com/linagora/twake-calendar-integration-tests/issues/176


## AMQP scheduling (`esn-sabre`):

```
# Default disable: env AMQP_SCHEDULING_ENABLED = false
mvn test

# Enable
mvn test -Pamqp-scheduling-on

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added AMQP scheduling guide, noting default-disabled behavior and example to enable it for tests.

* **Tests**
  * Test setup supports running both default and AMQP-scheduling-enabled runs, producing separate test reports and archived artifacts.
  * CI pipeline split into pre-build and two test stages to run and collect results for both configurations.

* **Chores**
  * Test environment now propagates AMQP scheduling setting into test containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->