### PR TITLE
Use the ITIP HTTP method directly for iTIP calls, instead of using the "X-HTTP-Method-Override: ITIP" header.

### DIFF
--- a/src/test/java/com/linagora/dav/CalDavClient.java
+++ b/src/test/java/com/linagora/dav/CalDavClient.java
@@ -313,13 +313,12 @@ public class CalDavClient {
             });
     }
 
-    public void postCounter(OpenPaasUser openPaaSUser, String attendeeEventUid, CounterRequest counterRequest) {
+    public void sendITIP(OpenPaasUser openPaaSUser, String attendeeEventUid, CounterRequest counterRequest) {
         URI uri = URI.create("/calendars/" + openPaaSUser.id() + "/" + openPaaSUser.id() + "/" + attendeeEventUid + ".ics");
         httpClient.headers(headers -> openPaaSUser.impersonatedBasicAuth(headers)
                 .add("Content-Type", "application/calendar+json")
-                .add("Accept", "application/json, text/plain, */*")
-                .add("x-http-method-override", "ITIP"))
-            .request(HttpMethod.POST)
+                .add("Accept", "application/json, text/plain, */*"))
+            .request(new HttpMethod("ITIP"))
             .uri(uri.toString())
             .send(Mono.just(Unpooled.wrappedBuffer(counterRequest.toJson().getBytes(StandardCharsets.UTF_8))))
             .responseSingle((response, responseContent) -> {

--- a/src/test/java/com/linagora/dav/contracts/EmailAMQPMessageContract.java
+++ b/src/test/java/com/linagora/dav/contracts/EmailAMQPMessageContract.java
@@ -680,7 +680,7 @@ public abstract class EmailAMQPMessageContract {
             testUser.email(),
             eventUid,
             1);
-        calDavClient.postCounter(testUser2, attendeeEventId, counterRequest);
+        calDavClient.sendITIP(testUser2, attendeeEventId, counterRequest);
         String expectedEventIcs = """
             BEGIN:VCALENDAR
             VERSION:2.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized the calendar counter request implementation to use the standard ITIP HTTP method, eliminating legacy header-based protocol overrides for improved standards compliance, better interoperability, and enhanced overall code clarity.

* **Tests**
  * Updated and validated test coverage to ensure calendar counter requests and associated email notification workflows function correctly with the new standards-compliant implementation approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->