### PR TITLE
Test admin modify resource events when subscribing again

### DIFF
--- a/src/test/java/com/linagora/dav/CalDavClient.java
+++ b/src/test/java/com/linagora/dav/CalDavClient.java
@@ -394,6 +394,37 @@ public class CalDavClient {
         sendDelegationRequest(user, uri, payload);
     }
 
+    public void grantDelegation(String entityId, OpenPaasUser delegatedUser, DelegationRight right, String token) {
+        grantDelegations(entityId, Map.of(delegatedUser, right), token);
+    }
+
+    public void grantDelegations(String entityId, Map<OpenPaasUser, DelegationRight> delegations, String token) {
+        String uri = "/calendars/" + entityId + "/" + entityId + ".json";
+
+        String setEntries = delegations.entrySet().stream()
+            .map(entry -> """
+                {
+                  "dav:href": "mailto:{email}",
+                  {right}
+                }
+                """.replace("{email}", entry.getKey().email())
+                .replace("{right}", entry.getValue().getValue()))
+            .collect(Collectors.joining(","));
+
+        String payload = """
+            {
+              "share": {
+                "set": [
+                  {entries}
+                ],
+                "remove": []
+              }
+            }
+            """.replace("{entries}", setEntries);
+
+        sendDelegationRequest(uri, payload, token);
+    }
+
     public DavResponse findEventsByTime(OpenPaasUser user, String start, String end) {
         return findEventsByTime(user, CalendarURL.from(user.id()), start, end);
     }
@@ -440,6 +471,26 @@ public class CalDavClient {
 
     private void sendDelegationRequest(OpenPaasUser user, String uri, String payload) {
         httpClient.headers(headers -> user.impersonatedBasicAuth(headers)
+                .add(HttpHeaderNames.CONTENT_TYPE, "application/json;charset=UTF-8")
+                .add(HttpHeaderNames.ACCEPT, "application/json, text/plain, */*"))
+            .request(HttpMethod.POST)
+            .uri(uri)
+            .send(Mono.just(Unpooled.wrappedBuffer(payload.getBytes(StandardCharsets.UTF_8))))
+            .responseSingle((response, responseContent) -> {
+                if (response.status().code() == 200) {
+                    return Mono.empty();
+                }
+                return responseContent.asString(StandardCharsets.UTF_8)
+                    .switchIfEmpty(Mono.just(StringUtils.EMPTY))
+                    .flatMap(errorBody -> Mono.error(new RuntimeException("""
+                        Unexpected status code: %d when sharing calendar '%s'
+                        %s
+                        """.formatted(response.status().code(), uri, errorBody))));
+            }).block();
+    }
+
+    private void sendDelegationRequest(String uri, String payload, String token) {
+        httpClient.headers(headers -> headers.add("TwakeCalendarToken", token)
                 .add(HttpHeaderNames.CONTENT_TYPE, "application/json;charset=UTF-8")
                 .add(HttpHeaderNames.ACCEPT, "application/json, text/plain, */*"))
             .request(HttpMethod.POST)

--- a/src/test/java/com/linagora/dav/CalDavClient.java
+++ b/src/test/java/com/linagora/dav/CalDavClient.java
@@ -422,7 +422,15 @@ public class CalDavClient {
             }
             """.replace("{entries}", setEntries);
 
-        sendDelegationRequest(uri, payload, token);
+        try{
+            sendDelegationRequest(uri, payload, token);
+        } catch (Exception e) {
+            if (e.getMessage().contains("Could not find node at path:")) {    // Retry once on first creation because DAV data not be provisioned yet.
+                sendDelegationRequest(uri, payload, token);
+            } else {
+                throw e;
+            }
+        }
     }
 
     public DavResponse findEventsByTime(OpenPaasUser user, String start, String end) {

--- a/src/test/java/com/linagora/dav/contracts/CalendarSharingContract.java
+++ b/src/test/java/com/linagora/dav/contracts/CalendarSharingContract.java
@@ -2035,6 +2035,90 @@ public abstract class CalendarSharingContract {
             .hasMessageContaining("User did not have the required privileges");
     }
 
+    @Test
+    void adminShouldBeAbleToModifyResourceEventsWhenDeletingSubscriptionAndThenSubscribingAgain() {
+        // GIVEN: a resource with alice as admin
+        OpenPaaSResource resource = extension().getDockerTwakeCalendarSetupSingleton()
+            .getTwakeCalendarProvisioningService()
+            .createResource("tv-room", "Shared TV Room", alice)
+            .block();
+
+        try {
+            calDavClient.getCalendarEvent(alice, URI.create("/calendars/" + alice.id() + "/" + alice.id() + "/event.ics"));
+        } catch (Exception ignored) {
+        }
+
+        // AND: alice is granted read-write delegation on the resource calendar
+        String token = extension().twakeCalendarProvisioningService().generateToken();
+        try {
+            // To ensure calendar directory is activated
+            calDavClient.grantDelegation(resource.id(), alice, CalDavClient.DelegationRight.READ_WRITE, token);
+        } catch (Exception ignored) {
+        }
+        calDavClient.grantDelegation(resource.id(), alice, CalDavClient.DelegationRight.READ_WRITE, token);
+
+        // AND: an event exists in the resource calendar
+        String eventUid = "event-" + UUID.randomUUID();
+        String summary = "Daily TV Room Booking";
+        String calendarData = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Sabre//Sabre VObject 4.1.3//EN
+            CALSCALE:GREGORIAN
+            BEGIN:VEVENT
+            UID:%s
+            DTSTAMP:20251016T020000Z
+            SEQUENCE:1
+            DTSTART;TZID=Asia/Ho_Chi_Minh:20251017T090000
+            DTEND;TZID=Asia/Ho_Chi_Minh:20251017T100000
+            SUMMARY:%s
+            LOCATION:Twake Meeting Room
+            DESCRIPTION:Auto-generated test event involving resource.
+            ORGANIZER;CN=Bob:mailto:%s
+            ATTENDEE;PARTSTAT=ACCEPTED;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:%s
+            ATTENDEE;PARTSTAT=TENTATIVE;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=RESOURCE;CN=resource:mailto:%s@open-paas.org
+            END:VEVENT
+            END:VCALENDAR
+            """.formatted(eventUid, summary, bob.email(), bob.email(), resource.id());
+
+        calDavClient.upsertCalendarEvent(bob, eventUid, calendarData);
+
+        // WHEN: alice deletes the calendar copy created by delegation
+        CalendarURL calendarURL = calDavClient.findUserCalendars(alice).collectList().block()
+            .stream().filter(url -> !url.base().equals(url.calendarId())).findAny().get();
+        calDavClient.deleteCalendar(alice, calendarURL);
+
+        // AND: Alice subscribes to the resource calendar again
+        SubscribedCalendarRequest subscribedCalendarRequest = SubscribedCalendarRequest.builder()
+            .id(UUID.randomUUID().toString())
+            .sourceUserId(resource.id())
+            .name("TV Room Calendar")
+            .readOnly(false)
+            .build();
+        calDavClient.subscribeToSharedCalendar(alice, subscribedCalendarRequest);
+
+        String subscribedCalendarURI = "/calendars/" + alice.id() + "/" + subscribedCalendarRequest.id() + "/";
+        String modifiedICS = calendarData.replace(summary, "Hacked by Alice!");
+
+        // THEN: the event in the resource calendar should be updated successfully by alice
+        List<JsonNode> aliceEvents = calDavClient.reportCalendarEvents(alice, subscribedCalendarURI,
+                Instant.parse("2024-09-01T00:00:00Z"), Instant.parse("2026-11-01T00:00:00Z"))
+            .collectList().block();
+
+        assertThat(aliceEvents).hasSize(1);
+
+        String eventHref = aliceEvents.getFirst().path("_links").path("self").path("href").asText();
+        calDavClient.upsertCalendarEvent(alice, URI.create(eventHref), modifiedICS);
+
+        List<JsonNode> updatedEvents = calDavClient.reportCalendarEvents(alice, subscribedCalendarURI,
+                Instant.parse("2024-09-01T00:00:00Z"), Instant.parse("2026-11-01T00:00:00Z"))
+            .collectList().block();
+        assertThat(updatedEvents).hasSize(1);
+        String updatedEventJson = updatedEvents.getFirst().toString();
+
+        assertThat(updatedEventJson).contains("Hacked by Alice!");
+    }
+
     @Disabled("https://github.com/linagora/esn-sabre/issues/51")
     @Test
     void cannotSubscribeToResourceFromAnotherDomain() {

--- a/src/test/java/com/linagora/dav/contracts/CalendarSharingContract.java
+++ b/src/test/java/com/linagora/dav/contracts/CalendarSharingContract.java
@@ -2035,6 +2035,7 @@ public abstract class CalendarSharingContract {
             .hasMessageContaining("User did not have the required privileges");
     }
 
+    @Disabled("https://github.com/linagora/twake-calendar-side-service/issues/654")
     @Test
     void adminShouldBeAbleToModifyResourceEventsWhenDeletingSubscriptionAndThenSubscribingAgain() {
         // GIVEN: a resource with alice as admin
@@ -2050,11 +2051,6 @@ public abstract class CalendarSharingContract {
 
         // AND: alice is granted read-write delegation on the resource calendar
         String token = extension().twakeCalendarProvisioningService().generateToken();
-        try {
-            // To ensure calendar directory is activated
-            calDavClient.grantDelegation(resource.id(), alice, CalDavClient.DelegationRight.READ_WRITE, token);
-        } catch (Exception ignored) {
-        }
         calDavClient.grantDelegation(resource.id(), alice, CalDavClient.DelegationRight.READ_WRITE, token);
 
         // AND: an event exists in the resource calendar
@@ -2104,8 +2100,6 @@ public abstract class CalendarSharingContract {
         List<JsonNode> aliceEvents = calDavClient.reportCalendarEvents(alice, subscribedCalendarURI,
                 Instant.parse("2024-09-01T00:00:00Z"), Instant.parse("2026-11-01T00:00:00Z"))
             .collectList().block();
-
-        assertThat(aliceEvents).hasSize(1);
 
         String eventHref = aliceEvents.getFirst().path("_links").path("self").path("href").asText();
         calDavClient.upsertCalendarEvent(alice, URI.create(eventHref), modifiedICS);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token-based delegation for calendar sharing, allowing granting of specific access rights to others using tokens.

* **Tests**
  * Added a (currently disabled) acceptance test covering delegation-driven workflows: granting via token, deleting a subscription, re-subscribing, and verifying delegated edit/upsert behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->