### PR TITLE
reduce await timeout

### DIFF
--- a/src/test/java/com/linagora/dav/contracts/ContactAMQPMessageContract.java
+++ b/src/test/java/com/linagora/dav/contracts/ContactAMQPMessageContract.java
@@ -45,7 +45,7 @@ public abstract class ContactAMQPMessageContract {
         .with()
         .pollDelay(Duration.ofMillis(500))
         .await();
-    private final ConditionFactory awaitAtMost = calmlyAwait.atMost(200, TimeUnit.SECONDS);
+    private final ConditionFactory awaitAtMost = calmlyAwait.atMost(30, TimeUnit.SECONDS);
 
     private CardDavClient cardDavClient;
 

--- a/src/test/java/com/linagora/dav/contracts/EmailAMQPMessageContract.java
+++ b/src/test/java/com/linagora/dav/contracts/EmailAMQPMessageContract.java
@@ -58,7 +58,7 @@ public abstract class EmailAMQPMessageContract {
         .with()
         .pollDelay(Duration.ofMillis(500))
         .await();
-    private final ConditionFactory awaitAtMost = calmlyAwait.atMost(200, TimeUnit.SECONDS);
+    private final ConditionFactory awaitAtMost = calmlyAwait.atMost(30, TimeUnit.SECONDS);
 
     private CalDavClient calDavClient;
 

--- a/src/test/java/com/linagora/dav/contracts/ResourceAMQPMessageContract.java
+++ b/src/test/java/com/linagora/dav/contracts/ResourceAMQPMessageContract.java
@@ -52,7 +52,7 @@ public abstract class ResourceAMQPMessageContract {
         .with()
         .pollDelay(Duration.ofMillis(500))
         .await();
-    private final ConditionFactory awaitAtMost = calmlyAwait.atMost(200, TimeUnit.SECONDS);
+    private final ConditionFactory awaitAtMost = calmlyAwait.atMost(30, TimeUnit.SECONDS);
 
     private CalDavClient calDavClient;
     

--- a/src/test/java/com/linagora/dav/contracts/SearchAMQPMessageContract.java
+++ b/src/test/java/com/linagora/dav/contracts/SearchAMQPMessageContract.java
@@ -53,7 +53,7 @@ public abstract class SearchAMQPMessageContract {
         .with()
         .pollDelay(Duration.ofMillis(500))
         .await();
-    private final ConditionFactory awaitAtMost = calmlyAwait.atMost(200, TimeUnit.SECONDS);
+    private final ConditionFactory awaitAtMost = calmlyAwait.atMost(30, TimeUnit.SECONDS);
 
     private CalDavClient calDavClient;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Optimized timeout thresholds for asynchronous message assertion tests across AMQP contracts, reducing the maximum wait duration from 200 to 30 seconds. This change accelerates test execution while maintaining assertion validity by enforcing stricter time constraints for message delivery and condition verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->