### PR TITLE
test(caldav-delegation): cover PUT on source calendar denied for READ delegate

### DIFF
--- a/src/test/java/com/linagora/dav/contracts/CalDavDelegationContract.java
+++ b/src/test/java/com/linagora/dav/contracts/CalDavDelegationContract.java
@@ -1414,6 +1414,49 @@ public abstract class CalDavDelegationContract {
             .hasMessageContaining("Unexpected status code: 403 when create/update calendar object");
     }
 
+    @Test
+    void putCalendarEventShouldThrowErrorWhenSourceCalendarOnlyHasReadRight() {
+        OpenPaasUser bob = dockerExtension().newTestUser();
+        OpenPaasUser alice = dockerExtension().newTestUser();
+
+        // GIVEN Bob has a calendar
+        // AND Bob delegates that calendar to Alice in read-only mode
+        calDavClient.grantDelegation(bob, bob.id(), alice, DelegationRight.READ);
+
+        String eventUid = UUID.randomUUID().toString();
+        String calendarData = TwakeCalendarEvent.builder()
+            .uid(eventUid)
+            .organizer(bob.email())
+            .summary("Sprint planning #01")
+            .location("Twake Meeting Room")
+            .description("This is a meeting to discuss the sprint planning for the next week.")
+            .dtstart("20300411T100000")
+            .dtend("20300411T110000")
+            .build()
+            .toString();
+
+        String updatedCalendarData = TwakeCalendarEvent.builder()
+            .uid(eventUid)
+            .organizer(bob.email())
+            .summary("Updated Sprint planning #01")
+            .location("Twake Meeting Room")
+            .description("This is a meeting to discuss the sprint planning for the next week.")
+            .dtstart("20300411T100000")
+            .dtend("20300411T110000")
+            .build()
+            .toString();
+
+        URI bobSourceCalendarEventUri = URI.create("/calendars/" + bob.id() + "/" + bob.id() + "/" + eventUid + ".ics");
+
+        // WHEN Bob creates and updates the event directly in his SOURCE calendar
+        calDavClient.upsertCalendarEvent(bob, bobSourceCalendarEventUri, calendarData);
+
+        // WHEN Alice tries to update the same event directly in Bob SOURCE calendar
+        // THEN a 403 error is thrown
+        assertThatThrownBy(() -> calDavClient.upsertCalendarEvent(alice, bobSourceCalendarEventUri, updatedCalendarData))
+            .hasMessageContaining("Unexpected status code: 403 when create/update calendar object");
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {"READ_WRITE", "ADMIN"})
     void aliceCanCreateEventsInReadOnlyDelegationWithDAVWhenAtLeastWriteRight(String param) throws Exception {


### PR DESCRIPTION
ref https://github.com/linagora/james-project-private/issues/1208

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test verification for read-only calendar delegation access control to ensure proper permission enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->