### PR TITLE
test(amqp email) – update test for stability & cleanup assert calendar 

### DIFF
--- a/src/test/java/com/linagora/dav/CalendarAssert.java
+++ b/src/test/java/com/linagora/dav/CalendarAssert.java
@@ -1,0 +1,119 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+package com.linagora.dav;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+
+import org.assertj.core.api.AbstractAssert;
+
+import net.fortuna.ical4j.model.Calendar;
+import net.fortuna.ical4j.model.Property;
+import net.fortuna.ical4j.model.PropertyList;
+
+public class CalendarAssert extends AbstractAssert<CalendarAssert, Calendar> {
+
+    private final List<UnaryOperator<Calendar>> transformations = new ArrayList<>();
+
+    private CalendarAssert(Calendar actual) {
+        super(actual, CalendarAssert.class);
+    }
+
+    public static CalendarAssert assertThatCalendar(Calendar actual) {
+        return new CalendarAssert(actual);
+    }
+
+    public static CalendarAssert assertThatCalendar(String ics) {
+        return new CalendarAssert(CalendarUtil.parseIcsAndSanitize(ics));
+    }
+
+    public CalendarAssert ignoringParticipantScheduleStatus() {
+        transformations.add(calendar -> {
+            Calendar copy = calendar.copy();
+            CalendarUtil.removeParticipantScheduleStatus(copy);
+            return copy;
+        });
+        return this;
+    }
+
+    public CalendarAssert ignoringProperties(String... propertyNames) {
+        transformations.add(calendar -> removeProperties(calendar, propertyNames));
+        return this;
+    }
+
+    @Override
+    public CalendarAssert isEqualTo(Object expected) {
+        if (expected instanceof Calendar) {
+            return isEqualToCalendar((Calendar) expected);
+        }
+        if (expected instanceof String) {
+            return isEqualToCalendar(CalendarUtil.parseIcsAndSanitize((String) expected));
+        }
+        return super.isEqualTo(expected);
+    }
+
+    private CalendarAssert isEqualToCalendar(Calendar expected) {
+        isNotNull();
+        Calendar transformedActual = applyTransformations(actual);
+        Calendar transformedExpected = applyTransformations(expected);
+        assertNormalizedEquals(transformedActual, transformedExpected);
+        return this;
+    }
+
+    private Calendar applyTransformations(Calendar calendar) {
+        Calendar result = calendar.copy();
+        for (UnaryOperator<Calendar> transformation : transformations) {
+            result = transformation.apply(result);
+        }
+        return result;
+    }
+
+    private void assertNormalizedEquals(Calendar actual, Calendar expected) {
+        Calendar sortedActual = reSortProperties(actual);
+        Calendar sortedExpected = reSortProperties(expected);
+
+        if (!sortedActual.equals(sortedExpected)) {
+            failWithMessage("Expected calendar:%n%s%nbut was:%n%s", sortedExpected, sortedActual);
+        }
+    }
+
+    private static Calendar reSortProperties(Calendar calendar) {
+        List<Property> sortedCalProps = calendar.getProperties().stream()
+            .sorted(Comparator.comparing(Property::toString))
+            .collect(Collectors.toList());
+        calendar.setPropertyList(new PropertyList(sortedCalProps));
+
+        calendar.getComponents().forEach(component -> {
+            List<Property> sortedProps = component.getProperties().stream()
+                .sorted(Comparator.comparing(Property::toString))
+                .collect(Collectors.toList());
+            component.setPropertyList(new PropertyList(sortedProps));
+        });
+
+        return calendar;
+    }
+
+    private static Calendar removeProperties(Calendar calendar, String... propertyNames) {
+        Calendar copy = calendar.copy();
+        CalendarUtil.removeAllProperties(copy, propertyNames);
+        return copy;
+    }
+}

--- a/src/test/java/com/linagora/dav/contracts/CalDavContract.java
+++ b/src/test/java/com/linagora/dav/contracts/CalDavContract.java
@@ -18,6 +18,7 @@
 
 package com.linagora.dav.contracts;
 
+import static com.linagora.dav.CalendarAssert.assertThatCalendar;
 import static com.linagora.dav.TestUtil.body;
 import static com.linagora.dav.TestUtil.execute;
 import static com.linagora.dav.TestUtil.executeNoContent;
@@ -961,9 +962,7 @@ public abstract class CalDavContract {
         assertThat(response.status().code()).isEqualTo(201);
         assertThat(response2.status()).isEqualTo(200);
 
-        Calendar actualCalendar = CalendarUtil.parseIcs(response2.body());
-        actualCalendar.removeAll(Property.PRODID);
-        Calendar expectedCalendar = CalendarUtil.parseIcs("BEGIN:VCALENDAR\n" +
+        assertThatCalendar(response2.body()).isEqualTo("BEGIN:VCALENDAR\n" +
             "VERSION:2.0\n" +
             "CALSCALE:GREGORIAN\n" +
             "X-WR-CALNAME:#default\n" +
@@ -1009,8 +1008,6 @@ public abstract class CalDavContract {
             "SEQUENCE:0\n" +
             "END:VEVENT\n" +
             "END:VCALENDAR\n");
-
-        assertThat(actualCalendar).isEqualTo(expectedCalendar);
     }
 
     @Test
@@ -1825,14 +1822,7 @@ public abstract class CalDavContract {
                 Map.of("cal", "urn:ietf:params:xml:ns:caldav")
             );
 
-            Calendar actualCalendar = CalendarUtil.parseIcs(actual);
-            Calendar expectedCalendar = CalendarUtil.parseIcs(updatedCalendarData);
-            actualCalendar.removeAll(Property.PRODID);
-            actualCalendar.getComponent(Component.VEVENT).get().removeAll(Property.DTSTAMP);
-            expectedCalendar.removeAll(Property.PRODID);
-            expectedCalendar.getComponent(Component.VEVENT).get().removeAll(Property.DTSTAMP);
-
-            assertThat(actualCalendar).isEqualTo(expectedCalendar);
+            assertThatCalendar(actual).isEqualTo(updatedCalendarData);
         });
     }
 
@@ -1899,14 +1889,7 @@ public abstract class CalDavContract {
                 Map.of("cal", "urn:ietf:params:xml:ns:caldav")
             );
 
-            Calendar actualCalendar = CalendarUtil.parseIcs(actual);
-            Calendar expectedCalendar = CalendarUtil.parseIcs(updatedCalendarData);
-            actualCalendar.removeAll(Property.PRODID);
-            actualCalendar.getComponent(Component.VEVENT).get().removeAll(Property.DTSTAMP);
-            expectedCalendar.removeAll(Property.PRODID);
-            expectedCalendar.getComponent(Component.VEVENT).get().removeAll(Property.DTSTAMP);
-
-            assertThat(actualCalendar).isEqualTo(expectedCalendar);
+            assertThatCalendar(actual).isEqualTo(updatedCalendarData);
         });
     }
 
@@ -1973,11 +1956,9 @@ public abstract class CalDavContract {
                 Map.of("cal", "urn:ietf:params:xml:ns:caldav")
             );
 
-            Calendar actualCalendar = CalendarUtil.parseIcs(actual);
-            Calendar expectedCalendar = CalendarUtil.parseIcs(updatedCalendarData);
-            CalendarUtil.removeParticipantScheduleStatus(actualCalendar);
-            CalendarUtil.removeParticipantScheduleStatus(expectedCalendar);
-            assertThat(actualCalendar).isEqualTo(expectedCalendar);
+            assertThatCalendar(actual)
+                .ignoringParticipantScheduleStatus()
+                .isEqualTo(updatedCalendarData);
         });
     }
 
@@ -2409,18 +2390,10 @@ public abstract class CalDavContract {
             String actual = XMLUtil.extractByXPath(response.body(),
                 "//cal:calendar-data", Map.of("cal", "urn:ietf:params:xml:ns:caldav"));
 
-            Calendar actualCalendar = CalendarUtil.parseIcsAndSanitize(actual);
-            Calendar expectedCalendar = CalendarUtil.parseIcsAndSanitize(calendarData);
-            actualCalendar.removeAll(Property.PRODID);
-            actualCalendar.getComponents(Component.VEVENT)
-                .forEach(calendarComponent -> calendarComponent.removeAll(Property.DTSTAMP).removeAll(Property.SEQUENCE));
-            expectedCalendar.removeAll(Property.PRODID);
-            expectedCalendar.getComponents(Component.VEVENT)
-                .forEach(calendarComponent -> calendarComponent.removeAll(Property.DTSTAMP).removeAll(Property.SEQUENCE));
-            CalendarUtil.removeParticipantScheduleStatus(actualCalendar);
-            CalendarUtil.removeParticipantScheduleStatus(expectedCalendar);
-
-            assertThat(actualCalendar).isEqualTo(expectedCalendar);
+            assertThatCalendar(actual)
+                .ignoringProperties(Property.SEQUENCE)
+                .ignoringParticipantScheduleStatus()
+                .isEqualTo(calendarData);
         });
     }
 

--- a/src/test/java/com/linagora/dav/contracts/CalDavDelegationContract.java
+++ b/src/test/java/com/linagora/dav/contracts/CalDavDelegationContract.java
@@ -18,6 +18,7 @@
 
 package com.linagora.dav.contracts;
 
+import static com.linagora.dav.CalendarAssert.assertThatCalendar;
 import static com.linagora.dav.DockerTwakeCalendarExtension.QUEUE_NAME;
 import static com.linagora.dav.TestUtil.body;
 import static com.linagora.dav.TestUtil.execute;
@@ -317,13 +318,7 @@ public abstract class CalDavDelegationContract {
             "//cal:calendar-data",
             Map.of("cal", "urn:ietf:params:xml:ns:caldav"));
 
-        Calendar actualCalendar = CalendarUtil.parseIcs(actual);
-        Calendar expectedCalendar = CalendarUtil.parseIcs(calendarData);
-        actualCalendar.removeAll(Property.PRODID);
-        actualCalendar.getComponent(Component.VEVENT).get().removeAll(Property.DTSTAMP);
-        expectedCalendar.removeAll(Property.PRODID);
-        expectedCalendar.getComponent(Component.VEVENT).get().removeAll(Property.DTSTAMP);
-        assertThat(actualCalendar).isEqualTo(expectedCalendar);
+        assertThatCalendar(actual).isEqualTo(calendarData);
     }
 
     @ParameterizedTest

--- a/src/test/java/com/linagora/dav/contracts/CalendarSharingContract.java
+++ b/src/test/java/com/linagora/dav/contracts/CalendarSharingContract.java
@@ -18,6 +18,7 @@
 
 package com.linagora.dav.contracts;
 
+import static com.linagora.dav.CalendarAssert.assertThatCalendar;
 import static com.linagora.dav.TestUtil.body;
 import static com.linagora.dav.TestUtil.execute;
 import static io.restassured.RestAssured.given;
@@ -52,7 +53,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linagora.dav.AmqpTestHelper;
 import com.linagora.dav.CalDavClient;
 import com.linagora.dav.CalendarURL;
-import com.linagora.dav.CalendarUtil;
 import com.linagora.dav.DavResponse;
 import com.linagora.dav.DockerTwakeCalendarExtension;
 import com.linagora.dav.DockerTwakeCalendarSetup;
@@ -69,9 +69,6 @@ import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.config.EncoderConfig;
 import io.restassured.config.RestAssuredConfig;
 import io.restassured.http.ContentType;
-import net.fortuna.ical4j.model.Calendar;
-import net.fortuna.ical4j.model.Component;
-import net.fortuna.ical4j.model.Property;
 
 public abstract class CalendarSharingContract {
 
@@ -326,14 +323,7 @@ public abstract class CalendarSharingContract {
             "//cal:calendar-data",
             Map.of("cal", "urn:ietf:params:xml:ns:caldav"));
 
-        Calendar actualCalendar = CalendarUtil.parseIcs(actual);
-        Calendar expectedCalendar = CalendarUtil.parseIcs(calendarData);
-        actualCalendar.removeAll(Property.PRODID);
-        actualCalendar.getComponent(Component.VEVENT).get().removeAll(Property.DTSTAMP);
-        expectedCalendar.removeAll(Property.PRODID);
-        expectedCalendar.getComponent(Component.VEVENT).get().removeAll(Property.DTSTAMP);
-
-        AssertionsForClassTypes.assertThat(actualCalendar).isEqualTo(expectedCalendar);
+        assertThatCalendar(actual).isEqualTo(calendarData);
     }
 
     @Test

--- a/src/test/java/com/linagora/dav/contracts/EmailAMQPMessageContract.java
+++ b/src/test/java/com/linagora/dav/contracts/EmailAMQPMessageContract.java
@@ -18,6 +18,7 @@
 
 package com.linagora.dav.contracts;
 
+import static com.linagora.dav.CalendarAssert.assertThatCalendar;
 import static com.linagora.dav.DockerTwakeCalendarExtension.QUEUE_NAME;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -989,9 +990,9 @@ public abstract class EmailAMQPMessageContract {
             UID:{eventUid}
             DTSTAMP:30250401T090000Z
             SEQUENCE:0
-            DTSTART;TZID=Asia/Ho_Chi_Minh:30250411T090000
-            DTEND;TZID=Asia/Ho_Chi_Minh:30250411T100000
-            RRULE:FREQ=WEEKLY;BYDAY=FR
+            DTSTART;TZID=Asia/Ho_Chi_Minh:21250411T090000
+            DTEND;TZID=Asia/Ho_Chi_Minh:21250411T100000
+            RRULE:FREQ=WEEKLY;BYDAY=WE
             SUMMARY:Weekly meeting
             LOCATION:Twake Meeting Room
             DESCRIPTION:Recurring test event
@@ -1012,7 +1013,7 @@ public abstract class EmailAMQPMessageContract {
 
         // Update the event by adding an EXDATE (exclude one occurrence)
         String updatedCalendarData = initialCalendarData.replace("SUMMARY:Weekly meeting",
-            "SUMMARY:Weekly meeting\nEXDATE;TZID=Asia/Ho_Chi_Minh:30250411T090000");
+            "SUMMARY:Weekly meeting\nEXDATE;TZID=Asia/Ho_Chi_Minh:21250411T090000");
         calDavClient.upsertCalendarEvent(testUser, eventUid, updatedCalendarData);
 
         // --- Expected CANCEL ICS ---
@@ -1029,9 +1030,9 @@ public abstract class EmailAMQPMessageContract {
             DESCRIPTION:Recurring test event
             ORGANIZER;CN=Van Tung TRAN:mailto:{organizerEmail}
             ATTENDEE;PARTSTAT=NEEDS-ACTION;CN=Benoît TELLIER;SCHEDULE-STATUS=1.1:mailto:{attendeeEmail}
-            DTSTART;TZID=Asia/Ho_Chi_Minh:30250411T090000
-            DTEND;TZID=Asia/Ho_Chi_Minh:30250411T090000
-            RECURRENCE-ID;TZID=Asia/Ho_Chi_Minh:30250411T090000
+            DTSTART;TZID=Asia/Ho_Chi_Minh:21250411T090000
+            DTEND;TZID=Asia/Ho_Chi_Minh:21250411T100000
+            RECURRENCE-ID;TZID=Asia/Ho_Chi_Minh:21250411T090000
             STATUS:CANCELLED
             END:VEVENT
             END:VCALENDAR
@@ -1062,9 +1063,9 @@ public abstract class EmailAMQPMessageContract {
                     assertThatJson(message.toString())
                         .isEqualTo(expectedJsonString);
 
-                    Calendar actualCalendar = CalendarUtil.parseIcsAndSanitize(message.path("event").asText());
-                    Calendar expectedCalendar = CalendarUtil.parseIcsAndSanitize(expectedCancelIcs);
-                    assertThat(actualCalendar).isEqualTo(expectedCalendar);
+                    assertThatCalendar(message.path("event").asText())
+                        .ignoringParticipantScheduleStatus()
+                        .isEqualTo(expectedCancelIcs);
                 }));
     }
 

--- a/src/test/java/com/linagora/dav/contracts/EmailAMQPMessageContract.java
+++ b/src/test/java/com/linagora/dav/contracts/EmailAMQPMessageContract.java
@@ -40,11 +40,9 @@ import org.testcontainers.shaded.org.awaitility.core.ConditionFactory;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.linagora.dav.AmqpTestHelper;
 import com.linagora.dav.CalDavClient;
-import com.linagora.dav.CalendarUtil;
 import com.linagora.dav.DockerTwakeCalendarExtension;
 import com.linagora.dav.OpenPaasUser;
 
-import net.fortuna.ical4j.model.Calendar;
 import net.minidev.json.parser.ParseException;
 
 public abstract class EmailAMQPMessageContract {
@@ -147,9 +145,7 @@ public abstract class EmailAMQPMessageContract {
                     assertThatJson(message.toString())
                         .isEqualTo(expected);
 
-                    Calendar actualCalendar = CalendarUtil.parseIcsAndSanitize(message.path("event").asText());
-                    Calendar expectedCalendar = CalendarUtil.parseIcsAndSanitize(expectedEventIcs);
-                    assertThat(actualCalendar).isEqualTo(expectedCalendar);
+                    assertThatCalendar(message.path("event").asText()).isEqualTo(expectedEventIcs);
                 }));
     }
 
@@ -335,9 +331,7 @@ public abstract class EmailAMQPMessageContract {
                     assertThatJson(message.toString())
                         .isEqualTo(expected);
 
-                    Calendar actualCalendar = CalendarUtil.parseIcsAndSanitize(message.path("event").asText());
-                    Calendar expectedCalendar = CalendarUtil.parseIcsAndSanitize(expectedEventIcs);
-                    assertThat(actualCalendar).isEqualTo(expectedCalendar);
+                    assertThatCalendar(message.path("event").asText()).isEqualTo(expectedEventIcs);
                 }));
     }
 
@@ -548,9 +542,7 @@ public abstract class EmailAMQPMessageContract {
                     assertThatJson(message.toString())
                         .isEqualTo(expected);
 
-                    Calendar actualCalendar = CalendarUtil.parseIcsAndSanitize(message.path("event").asText());
-                    Calendar expectedCalendar = CalendarUtil.parseIcsAndSanitize(expectedEventIcs);
-                    assertThat(actualCalendar).isEqualTo(expectedCalendar);
+                    assertThatCalendar(message.path("event").asText()).isEqualTo(expectedEventIcs);
                 }));
     }
 
@@ -640,9 +632,7 @@ public abstract class EmailAMQPMessageContract {
                     assertThatJson(message.toString())
                         .isEqualTo(expected);
 
-                    Calendar actualCalendar = CalendarUtil.parseIcsAndSanitize(message.path("event").asText());
-                    Calendar expectedCalendar = CalendarUtil.parseIcsAndSanitize(expectedEventIcs);
-                    assertThat(actualCalendar).isEqualTo(expectedCalendar);
+                    assertThatCalendar(message.path("event").asText()).isEqualTo(expectedEventIcs);
                 }));
     }
 
@@ -771,15 +761,11 @@ public abstract class EmailAMQPMessageContract {
                     assertThatJson(message.toString())
                         .isEqualTo(expected);
 
-                    Calendar actualCalendar = CalendarUtil.parseIcsAndSanitize(message.path("event").asText());
-                    Calendar expectedCalendar = CalendarUtil.parseIcsAndSanitize(expectedEventIcs);
-                    assertThat(actualCalendar).isEqualTo(expectedCalendar);
+                    assertThatCalendar(message.path("event").asText()).isEqualTo(expectedEventIcs);
 
-                    Calendar actualOldCalendar = CalendarUtil.parseIcsAndSanitize(message.path("oldEvent").asText());
-                    Calendar expectedOldCalendar = CalendarUtil.parseIcsAndSanitize(expectedOldEventIcs);
-                    CalendarUtil.removeParticipantScheduleStatus(actualOldCalendar);
-                    CalendarUtil.removeParticipantScheduleStatus(expectedOldCalendar);
-                    assertThat(actualOldCalendar).isEqualTo(expectedOldCalendar);
+                    assertThatCalendar(message.path("oldEvent").asText())
+                        .ignoringParticipantScheduleStatus()
+                        .isEqualTo(expectedOldEventIcs);
                 }));
     }
 
@@ -871,15 +857,11 @@ public abstract class EmailAMQPMessageContract {
                     assertThatJson(message.toString())
                         .isEqualTo(expected);
 
-                    Calendar actualCalendar = CalendarUtil.parseIcsAndSanitize(message.path("event").asText());
-                    Calendar expectedCalendar = CalendarUtil.parseIcsAndSanitize(expectedEventIcs);
-                    assertThat(actualCalendar).isEqualTo(expectedCalendar);
+                    assertThatCalendar(message.path("event").asText()).isEqualTo(expectedEventIcs);
 
-                    Calendar actualOldCalendar = CalendarUtil.parseIcsAndSanitize(message.path("oldEvent").asText());
-                    Calendar expectedOldCalendar = CalendarUtil.parseIcsAndSanitize(expectedOldEventIcs);
-                    CalendarUtil.removeParticipantScheduleStatus(actualOldCalendar);
-                    CalendarUtil.removeParticipantScheduleStatus(expectedOldCalendar);
-                    assertThat(actualOldCalendar).isEqualTo(expectedOldCalendar);
+                    assertThatCalendar(message.path("oldEvent").asText())
+                        .ignoringParticipantScheduleStatus()
+                        .isEqualTo(expectedOldEventIcs);
                 }));
     }
 
@@ -969,9 +951,7 @@ public abstract class EmailAMQPMessageContract {
                     assertThatJson(message.toString())
                         .isEqualTo(expectedJsonString);
 
-                    Calendar actualCalendar = CalendarUtil.parseIcsAndSanitize(message.path("event").asText());
-                    Calendar expectedCalendar = CalendarUtil.parseIcsAndSanitize(expectedEventIcs);
-                    assertThat(actualCalendar).isEqualTo(expectedCalendar);
+                    assertThatCalendar(message.path("event").asText()).isEqualTo(expectedEventIcs);
                 }));
     }
 
@@ -1065,6 +1045,7 @@ public abstract class EmailAMQPMessageContract {
 
                     assertThatCalendar(message.path("event").asText())
                         .ignoringParticipantScheduleStatus()
+                        .ignoringProperties("DTEND") // https://github.com/linagora/esn-sabre/issues/305
                         .isEqualTo(expectedCancelIcs);
                 }));
     }
@@ -1220,9 +1201,7 @@ public abstract class EmailAMQPMessageContract {
                     assertThatJson(message.toString())
                         .isEqualTo(expectedJsonString);
 
-                    Calendar actualCalendar = CalendarUtil.parseIcsAndSanitize(message.path("event").asText());
-                    Calendar expectedCalendar = CalendarUtil.parseIcsAndSanitize(expectedEventIcs);
-                    assertThat(actualCalendar).isEqualTo(expectedCalendar);
+                    assertThatCalendar(message.path("event").asText()).isEqualTo(expectedEventIcs);
                 });
         });
     }

--- a/src/test/java/com/linagora/dav/contracts/ITIPRequestContract.java
+++ b/src/test/java/com/linagora/dav/contracts/ITIPRequestContract.java
@@ -18,6 +18,7 @@
 
 package com.linagora.dav.contracts;
 
+import static com.linagora.dav.CalendarAssert.assertThatCalendar;
 import static com.linagora.dav.TestUtil.execute;
 import static com.linagora.dav.contracts.CalendarSharingContract.MAPPER;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
@@ -1166,8 +1167,6 @@ public abstract class ITIPRequestContract {
         List<String> hrefsFromPropfind = awaitCalendarEntries(cedric, cedricInboxCollection, 1);
         String calendarInboxEventIcs = calDavClient.getCalendarEvent(cedric, URI.create(hrefsFromPropfind.getFirst()));
 
-        Calendar actualCalendar = CalendarUtil.parseIcsAndSanitize(calendarInboxEventIcs);
-
         String expectedInboxIcs = """
             BEGIN:VCALENDAR
             VERSION:2.0
@@ -1195,9 +1194,8 @@ public abstract class ITIPRequestContract {
             .replace("{CEDRIC_EMAIL}", cedric.email())
             .trim();
 
-        Calendar expectedCalendar = CalendarUtil.parseIcsAndSanitize(expectedInboxIcs);
-        assertThat(actualCalendar)
-            .isEqualTo(expectedCalendar);
+        assertThatCalendar(calendarInboxEventIcs)
+            .isEqualTo(expectedInboxIcs);
     }
 
     @Test
@@ -1212,7 +1210,6 @@ public abstract class ITIPRequestContract {
         List<String> hrefsFromPropfind = awaitCalendarEntries(cedric, cedricDefaultCalendar, 1);
 
         String actualEventIcs = calDavClient.getCalendarEvent(cedric, URI.create(hrefsFromPropfind.getFirst()));
-        Calendar actualCalendar = CalendarUtil.parseIcsAndSanitize(actualEventIcs);
 
         // THEN Cedric’s calendar should contain only the invited occurrence, without recurrence rules
         String expectedCalendarIcs = """
@@ -1241,12 +1238,10 @@ public abstract class ITIPRequestContract {
             .replace("{CEDRIC_EMAIL}", cedric.email())
             .trim();
 
-        Calendar expectedCalendar = CalendarUtil.parseIcsAndSanitize(expectedCalendarIcs);
-
         // Assert equality (logical content, ignoring order or minor formatting)
-        assertThat(actualCalendar)
+        assertThatCalendar(actualEventIcs)
             .as("Cedric's calendar should contain only the invited occurrence (#2), no recurrence rule")
-            .isEqualTo(expectedCalendar);
+            .isEqualTo(expectedCalendarIcs);
     }
 
     @Test
@@ -1269,7 +1264,6 @@ public abstract class ITIPRequestContract {
         String bobInbox = "/calendars/" + bob.id() + "/inbox";
         List<String> hrefsFromPropfind = awaitCalendarEntries(bob, bobInbox, 1);
         String actualInboxIcs = calDavClient.getCalendarEvent(bob, URI.create(hrefsFromPropfind.getFirst()));
-        Calendar actualReplyCalendar = CalendarUtil.parseIcsAndSanitize(actualInboxIcs);
 
         String expectedReplyIcs = """
             BEGIN:VCALENDAR
@@ -1295,10 +1289,9 @@ public abstract class ITIPRequestContract {
             .replace("{CEDRIC_EMAIL}", cedric.email())
             .trim();
 
-        Calendar expectedReplyCalendar = CalendarUtil.parseIcsAndSanitize(expectedReplyIcs);
-        assertThat(actualReplyCalendar)
+        assertThatCalendar(actualInboxIcs)
             .as("Bob's inbox should contain a single REPLY iTIP for the invited occurrence")
-            .isEqualTo(expectedReplyCalendar);
+            .isEqualTo(expectedReplyIcs);
 
         // Bob's default calendar should not duplicate events
         String bobDefaultCalendar = "/calendars/" + bob.id() + "/" + bob.id();
@@ -1617,7 +1610,6 @@ public abstract class ITIPRequestContract {
 
         URI latestInboxUri = URI.create(inboxAfterUpdate.getLast());
         String actualInboxIcs = calDavClient.getCalendarEvent(cedric, latestInboxUri);
-        Calendar actualCalendar = CalendarUtil.parseIcsAndSanitize(actualInboxIcs);
         String expectedInboxIcs = """
             BEGIN:VCALENDAR
             VERSION:2.0
@@ -1645,10 +1637,9 @@ public abstract class ITIPRequestContract {
             .replace("{CEDRIC_EMAIL}", cedric.email())
             .trim();
 
-        Calendar expectedCalendar = CalendarUtil.parseIcsAndSanitize(expectedInboxIcs);
-        assertThat(actualCalendar)
+        assertThatCalendar(actualInboxIcs)
             .as("Cedric should receive a proper REQUEST for the modified invited occurrence")
-            .isEqualTo(expectedCalendar);
+            .isEqualTo(expectedInboxIcs);
 
         // AND Cedric's calendar should reflect the updated time & summary
         String cedricDefaultCalendar = "/calendars/" + cedric.id() + "/" + cedric.id();
@@ -2659,7 +2650,8 @@ public abstract class ITIPRequestContract {
                 .replace("{ATTENDEE_EMAIL}", bob.email())
                 .replace("{EVENT_UID}", eventUid);
 
-        assertThat(CalendarUtil.parseIcsAndSanitize(calendarIc.replaceAll(";SCHEDULE-STATUS=[^:;\\r\\n]+", "")))
-            .isEqualTo(CalendarUtil.parseIcsAndSanitize(expectedCalendarIcs));
+        assertThatCalendar(calendarIc)
+            .ignoringParticipantScheduleStatus()
+            .isEqualTo(expectedCalendarIcs);
     }
 }

--- a/src/test/java/com/linagora/dav/contracts/ResourceAMQPMessageContract.java
+++ b/src/test/java/com/linagora/dav/contracts/ResourceAMQPMessageContract.java
@@ -18,6 +18,7 @@
 
 package com.linagora.dav.contracts;
 
+import static com.linagora.dav.CalendarAssert.assertThatCalendar;
 import static com.linagora.dav.DockerTwakeCalendarExtension.QUEUE_NAME;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,12 +38,10 @@ import org.testcontainers.shaded.org.awaitility.core.ConditionFactory;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.linagora.dav.AmqpTestHelper;
 import com.linagora.dav.CalDavClient;
-import com.linagora.dav.CalendarUtil;
 import com.linagora.dav.DockerTwakeCalendarExtension;
 import com.linagora.dav.OpenPaaSResource;
 import com.linagora.dav.OpenPaasUser;
 
-import net.fortuna.ical4j.model.Calendar;
 
 public abstract class ResourceAMQPMessageContract {
 
@@ -142,11 +141,9 @@ public abstract class ResourceAMQPMessageContract {
                     assertThatJson(message.toString())
                         .isEqualTo(expected);
 
-                    Calendar actualCalendar = CalendarUtil.parseIcsAndSanitize(message.path("ics").asText());
-                    Calendar expectedCalendar = CalendarUtil.parseIcsAndSanitize(expectedEventIcs);
-                    CalendarUtil.removeParticipantScheduleStatus(actualCalendar);
-                    CalendarUtil.removeParticipantScheduleStatus(expectedCalendar);
-                    assertThat(actualCalendar).isEqualTo(expectedCalendar);
+                    assertThatCalendar(message.path("ics").asText())
+                        .ignoringParticipantScheduleStatus()
+                        .isEqualTo(expectedEventIcs);
                 }));
     }
 
@@ -251,11 +248,9 @@ public abstract class ResourceAMQPMessageContract {
                     assertThatJson(message.toString())
                         .isEqualTo(expected);
 
-                    Calendar actualCalendar = CalendarUtil.parseIcsAndSanitize(message.path("ics").asText());
-                    Calendar expectedCalendar = CalendarUtil.parseIcsAndSanitize(expectedEventIcs);
-                    CalendarUtil.removeParticipantScheduleStatus(actualCalendar);
-                    CalendarUtil.removeParticipantScheduleStatus(expectedCalendar);
-                    assertThat(actualCalendar).isEqualTo(expectedCalendar);
+                    assertThatCalendar(message.path("ics").asText())
+                        .ignoringParticipantScheduleStatus()
+                        .isEqualTo(expectedEventIcs);
                 }));
     }
 
@@ -360,11 +355,9 @@ public abstract class ResourceAMQPMessageContract {
                     assertThatJson(message.toString())
                         .isEqualTo(expected);
 
-                    Calendar actualCalendar = CalendarUtil.parseIcsAndSanitize(message.path("ics").asText());
-                    Calendar expectedCalendar = CalendarUtil.parseIcsAndSanitize(expectedEventIcs);
-                    CalendarUtil.removeParticipantScheduleStatus(actualCalendar);
-                    CalendarUtil.removeParticipantScheduleStatus(expectedCalendar);
-                    assertThat(actualCalendar).isEqualTo(expectedCalendar);
+                    assertThatCalendar(message.path("ics").asText())
+                        .ignoringParticipantScheduleStatus()
+                        .isEqualTo(expectedEventIcs);
                 }));
     }
 

--- a/src/test/java/com/linagora/dav/contracts/SchedulingContract.java
+++ b/src/test/java/com/linagora/dav/contracts/SchedulingContract.java
@@ -18,6 +18,7 @@
 
 package com.linagora.dav.contracts;
 
+import static com.linagora.dav.CalendarAssert.assertThatCalendar;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
@@ -126,10 +127,9 @@ public abstract class SchedulingContract {
 
         // Then Cedric calendar contains an equivalent propagated event
         String actualCedricCalendarEventIcs = calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri);
-        Calendar actualCalendar = CalendarUtil.parseIcsAndSanitize(actualCedricCalendarEventIcs, IGNORED_CALENDAR_PROPERTIES);
-        Calendar expectedCalendar = CalendarUtil.parseIcsAndSanitize(expectedCedricCalendarEventIcs, IGNORED_CALENDAR_PROPERTIES);
-        assertThat(actualCalendar)
-            .isEqualTo(expectedCalendar);
+        assertThatCalendar(actualCedricCalendarEventIcs)
+            .ignoringProperties(IGNORED_CALENDAR_PROPERTIES)
+            .isEqualTo(expectedCedricCalendarEventIcs);
     }
 
     @Test
@@ -188,12 +188,10 @@ public abstract class SchedulingContract {
             .replace("{organizerEventUid}", organizerEventUid)
             .replace("{bobEmail}", bob.email())
             .replace("{cedricEmail}", cedric.email());
-        Calendar expectedCedricCalendar = CalendarUtil.parseIcs(expectedCedricCalendarEventIcs);
-
-        awaitAtMost.untilAsserted(() -> {
-            Calendar actualCedricCalendar = CalendarUtil.parseIcsAndSanitize(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri), IGNORED_CALENDAR_PROPERTIES);
-            assertThat(actualCedricCalendar).isEqualTo(expectedCedricCalendar);
-        });
+        awaitAtMost.untilAsserted(() ->
+            assertThatCalendar(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri))
+                .ignoringProperties(IGNORED_CALENDAR_PROPERTIES)
+                .isEqualTo(expectedCedricCalendarEventIcs));
     }
 
     @Test
@@ -560,14 +558,10 @@ public abstract class SchedulingContract {
             .replace("{bobEmail}", bob.email())
             .replace("{cedricEmail}", cedric.email())
             .replace("{aliceEmail}", alice.email());
-        Calendar expectedAliceCalendar = CalendarUtil.parseIcs(expectedAliceIcs);
-
-        awaitAtMost.untilAsserted(() -> {
-            Calendar actualAliceCalendar = CalendarUtil.parseIcsAndSanitize(
-                calDavClient.getCalendarEvent(alice, aliceCalendarEventUri),
-                IGNORED_CALENDAR_PROPERTIES);
-            assertThat(actualAliceCalendar).isEqualTo(expectedAliceCalendar);
-        });
+        awaitAtMost.untilAsserted(() ->
+            assertThatCalendar(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri))
+                .ignoringProperties(IGNORED_CALENDAR_PROPERTIES)
+                .isEqualTo(expectedAliceIcs));
     }
 
     @Test
@@ -628,16 +622,12 @@ public abstract class SchedulingContract {
             .replace("{bobEmail}", bob.email())
             .replace("{aliceEmail}", alice.email());
 
-        Calendar expectedAliceCalendar = CalendarUtil.parseIcs(expectedAliceEventIcs);
-
         String aliceCalendarEventId = awaitFirstEventId(alice);
         URI aliceCalendarEventUri = URI.create("/calendars/" + alice.id() + "/" + alice.id() + "/" + aliceCalendarEventId + ".ics");
-        awaitAtMost.untilAsserted(() -> {
-            Calendar actualAliceCalendar = CalendarUtil.parseIcsAndSanitize(
-                calDavClient.getCalendarEvent(alice, aliceCalendarEventUri),
-                IGNORED_CALENDAR_PROPERTIES);
-            assertThat(actualAliceCalendar).isEqualTo(expectedAliceCalendar);
-        });
+        awaitAtMost.untilAsserted(() ->
+            assertThatCalendar(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri))
+                .ignoringProperties(IGNORED_CALENDAR_PROPERTIES)
+                .isEqualTo(expectedAliceEventIcs));
     }
 
     @Test
@@ -699,13 +689,10 @@ public abstract class SchedulingContract {
             .replace("{organizerEventUid}", organizerEventUid)
             .replace("{bobEmail}", bob.email())
             .replace("{cedricEmail}", cedric.email());
-        Calendar expectedCedricCalendar = CalendarUtil.parseIcs(expectedCedricIcs);
-        awaitAtMost.untilAsserted(() -> {
-            Calendar actualCedricCalendar = CalendarUtil.parseIcsAndSanitize(
-                calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri),
-                IGNORED_CALENDAR_PROPERTIES);
-            assertThat(actualCedricCalendar).isEqualTo(expectedCedricCalendar);
-        });
+        awaitAtMost.untilAsserted(() ->
+            assertThatCalendar(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri))
+                .ignoringProperties(IGNORED_CALENDAR_PROPERTIES)
+                .isEqualTo(expectedCedricIcs));
 
         // When Cedric accepts only that invited occurrence
         String cedricAcceptedEventIcs = """
@@ -756,16 +743,13 @@ public abstract class SchedulingContract {
             .replace("{organizerEventUid}", organizerEventUid)
             .replace("{bobEmail}", bob.email())
             .replace("{cedricEmail}", cedric.email());
-        Calendar expectedOrganizerCalendar = CalendarUtil.parseIcs(expectedOrganizerIcs);
         URI bobCalendarEventUri = URI.create("/calendars/" + bob.id() + "/" + bob.id() + "/" + organizerEventUid + ".ics");
 
-        awaitAtMost.untilAsserted(() -> {
-            Calendar actualOrganizerCalendar = CalendarUtil.parseIcsAndSanitize(
-                calDavClient.getCalendarEvent(bob, bobCalendarEventUri),
-                IGNORED_CALENDAR_PROPERTIES);
-            CalendarUtil.removeParticipantScheduleStatus(actualOrganizerCalendar);
-            assertThat(actualOrganizerCalendar).isEqualTo(expectedOrganizerCalendar);
-        });
+        awaitAtMost.untilAsserted(() ->
+            assertThatCalendar(calDavClient.getCalendarEvent(bob, bobCalendarEventUri))
+                .ignoringProperties(IGNORED_CALENDAR_PROPERTIES)
+                .ignoringParticipantScheduleStatus()
+                .isEqualTo(expectedOrganizerIcs));
     }
 
     @Test
@@ -825,13 +809,10 @@ public abstract class SchedulingContract {
             .replace("{organizerEventUid}", organizerEventUid)
             .replace("{bobEmail}", bob.email())
             .replace("{cedricEmail}", cedric.email());
-        Calendar expectedCedricCalendar = CalendarUtil.parseIcs(expectedCedricIcs);
-        awaitAtMost.untilAsserted(() -> {
-            Calendar actualCedricCalendar = CalendarUtil.parseIcsAndSanitize(
-                calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri),
-                IGNORED_CALENDAR_PROPERTIES);
-            assertThat(actualCedricCalendar).isEqualTo(expectedCedricCalendar);
-        });
+        awaitAtMost.untilAsserted(() ->
+            assertThatCalendar(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri))
+                .ignoringProperties(IGNORED_CALENDAR_PROPERTIES)
+                .isEqualTo(expectedCedricIcs));
 
         // And Bob deletes only that invited occurrence by removing its override from payload
         String updatedOrganizerSeriesAfterOccRemovalIcs = """
@@ -874,14 +855,11 @@ public abstract class SchedulingContract {
             .replace("{organizerEventUid}", organizerEventUid)
             .replace("{bobEmail}", bob.email())
             .replace("{cedricEmail}", cedric.email());
-        Calendar expectedCedricCancelledInviteOccCal = CalendarUtil.parseIcs(expectedCedricCancelledInviteOccIcs);
-        awaitAtMost.untilAsserted(() -> {
-            Calendar actualCedricCancelledInviteOccCal = CalendarUtil.parseIcsAndSanitize(
-                calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri),
-                IGNORED_CALENDAR_PROPERTIES);
-            CalendarUtil.removeParticipantScheduleStatus(actualCedricCancelledInviteOccCal);
-            assertThat(actualCedricCancelledInviteOccCal).isEqualTo(expectedCedricCancelledInviteOccCal);
-        });
+        awaitAtMost.untilAsserted(() ->
+            assertThatCalendar(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri))
+                .ignoringProperties(IGNORED_CALENDAR_PROPERTIES)
+                .ignoringParticipantScheduleStatus()
+                .isEqualTo(expectedCedricCancelledInviteOccIcs));
     }
 
     @Test
@@ -934,14 +912,11 @@ public abstract class SchedulingContract {
 
         String cedricCalendarEventId = awaitFirstEventId(cedric);
         URI cedricCalendarEventUri = URI.create("/calendars/" + cedric.id() + "/" + cedric.id() + "/" + cedricCalendarEventId + ".ics");
-        Calendar expectedCedricCalendar = CalendarUtil.parseIcs(expectedCedricEventIcs);
 
-        awaitAtMost.untilAsserted(() -> {
-            Calendar actualCedricCalendar = CalendarUtil.parseIcsAndSanitize(
-                calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri),
-                IGNORED_CALENDAR_PROPERTIES);
-            assertThat(actualCedricCalendar).isEqualTo(expectedCedricCalendar);
-        });
+        awaitAtMost.untilAsserted(() ->
+            assertThatCalendar(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri))
+                .ignoringProperties(IGNORED_CALENDAR_PROPERTIES)
+                .isEqualTo(expectedCedricEventIcs));
     }
 
     @Test
@@ -1070,15 +1045,11 @@ public abstract class SchedulingContract {
             .replace("{organizerEventUid}", organizerEventUid)
             .replace("{bobEmail}", bob.email())
             .replace("{cedricEmail}", cedric.email());
-        Calendar expectedCedricCalendar = CalendarUtil.parseIcs(expectedCedricEventIcs);
-
         URI cedricCalendarEventUri = URI.create("/calendars/" + cedric.id() + "/" + cedric.id() + "/" + cedricCalendarEventId + ".ics");
-        awaitAtMost.untilAsserted(() -> {
-            Calendar actualCedricCalendar = CalendarUtil.parseIcsAndSanitize(
-                calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri),
-                IGNORED_CALENDAR_PROPERTIES);
-            assertThat(actualCedricCalendar).isEqualTo(expectedCedricCalendar);
-        });
+        awaitAtMost.untilAsserted(() ->
+            assertThatCalendar(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri))
+                .ignoringProperties(IGNORED_CALENDAR_PROPERTIES)
+                .isEqualTo(expectedCedricEventIcs));
     }
 
     @Test
@@ -1156,14 +1127,11 @@ public abstract class SchedulingContract {
             .replace("{organizerEventUid}", organizerEventUid)
             .replace("{bobEmail}", bob.email())
             .replace("{cedricEmail}", cedric.email());
-        Calendar expectedCedricCalendar = CalendarUtil.parseIcs(expectedCedricEventIcs);
         URI cedricCalendarEventUri = URI.create("/calendars/" + cedric.id() + "/" + cedric.id() + "/" + cedricCalendarEventId + ".ics");
-        awaitAtMost.untilAsserted(() -> {
-            Calendar actualCedricRecurringSeriesCalendar = CalendarUtil.parseIcsAndSanitize(
-                calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri),
-                IGNORED_CALENDAR_PROPERTIES);
-            assertThat(actualCedricRecurringSeriesCalendar).isEqualTo(expectedCedricCalendar);
-        });
+        awaitAtMost.untilAsserted(() ->
+            assertThatCalendar(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri))
+                .ignoringProperties(IGNORED_CALENDAR_PROPERTIES)
+                .isEqualTo(expectedCedricEventIcs));
     }
 
     @Test
@@ -1239,15 +1207,11 @@ public abstract class SchedulingContract {
             .replace("{organizerEventUid}", organizerEventUid)
             .replace("{bobEmail}", bob.email())
             .replace("{cedricEmail}", cedric.email());
-        Calendar expectedCedricUpdatedCalendar = CalendarUtil.parseIcs(expectedCedricEventIcs);
-
         URI cedricCalendarEventUri = URI.create("/calendars/" + cedric.id() + "/" + cedric.id() + "/" + cedricCalendarEventId + ".ics");
-        awaitAtMost.untilAsserted(() -> {
-            Calendar actualCedricUpdatedSeriesCalendar = CalendarUtil.parseIcsAndSanitize(
-                calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri),
-                IGNORED_CALENDAR_PROPERTIES);
-            assertThat(actualCedricUpdatedSeriesCalendar).isEqualTo(expectedCedricUpdatedCalendar);
-        });
+        awaitAtMost.untilAsserted(() ->
+            assertThatCalendar(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri))
+                .ignoringProperties(IGNORED_CALENDAR_PROPERTIES)
+                .isEqualTo(expectedCedricEventIcs));
     }
 
     @Test
@@ -1344,15 +1308,11 @@ public abstract class SchedulingContract {
             .replace("{organizerEventUid}", organizerEventUid)
             .replace("{bobEmail}", bob.email())
             .replace("{cedricEmail}", cedric.email());
-        Calendar expectedCedricRecurringSeriesCalendar = CalendarUtil.parseIcs(expectedCedricEventIcs);
-
         URI cedricCalendarEventUri = URI.create("/calendars/" + cedric.id() + "/" + cedric.id() + "/" + cedricCalendarEventId + ".ics");
-        awaitAtMost.untilAsserted(() -> {
-            Calendar actualCedricRecurringSeriesCalendar = CalendarUtil.parseIcsAndSanitize(
-                calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri),
-                IGNORED_CALENDAR_PROPERTIES);
-            assertThat(actualCedricRecurringSeriesCalendar).isEqualTo(expectedCedricRecurringSeriesCalendar);
-        });
+        awaitAtMost.untilAsserted(() ->
+            assertThatCalendar(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri))
+                .ignoringProperties(IGNORED_CALENDAR_PROPERTIES)
+                .isEqualTo(expectedCedricEventIcs));
     }
 
     @Test
@@ -1430,15 +1390,11 @@ public abstract class SchedulingContract {
             .replace("{organizerEventUid}", organizerEventUid)
             .replace("{bobEmail}", bob.email())
             .replace("{cedricEmail}", cedric.email());
-        Calendar expectedCedricCalendar = CalendarUtil.parseIcs(expectedCedricRecurringSeriesEventIcs);
-
         URI cedricCalendarEventUri = URI.create("/calendars/" + cedric.id() + "/" + cedric.id() + "/" + cedricCalendarEventId + ".ics");
-        awaitAtMost.untilAsserted(() -> {
-            Calendar actualCedricRecurringSeriesCalendar = CalendarUtil.parseIcsAndSanitize(
-                calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri),
-                IGNORED_CALENDAR_PROPERTIES);
-            assertThat(actualCedricRecurringSeriesCalendar).isEqualTo(expectedCedricCalendar);
-        });
+        awaitAtMost.untilAsserted(() ->
+            assertThatCalendar(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri))
+                .ignoringProperties(IGNORED_CALENDAR_PROPERTIES)
+                .isEqualTo(expectedCedricRecurringSeriesEventIcs));
     }
 
     @Test
@@ -1737,14 +1693,10 @@ public abstract class SchedulingContract {
             .replace("{bobEmail}", bob.email())
             .replace("{aliceEmail}", alice.email())
             .replace("{cedricEmail}", cedric.email());
-        Calendar expectedAliceCalendar = CalendarUtil.parseIcs(expectedAliceIcs);
-
-        awaitAtMost.untilAsserted(() -> {
-            Calendar actualAliceCalendar = CalendarUtil.parseIcsAndSanitize(
-                calDavClient.getCalendarEvent(alice, aliceCalendarEventUri),
-                IGNORED_CALENDAR_PROPERTIES);
-            assertThat(actualAliceCalendar).isEqualTo(expectedAliceCalendar);
-        });
+        awaitAtMost.untilAsserted(() ->
+            assertThatCalendar(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri))
+                .ignoringProperties(IGNORED_CALENDAR_PROPERTIES)
+                .isEqualTo(expectedAliceIcs));
     }
 
     @Test
@@ -1825,14 +1777,10 @@ public abstract class SchedulingContract {
             .replace("{bobEmail}", bob.email())
             .replace("{cedricEmail}", cedric.email())
             .replace("{aliceEmail}", alice.email());
-        Calendar expectedAliceCalendar = CalendarUtil.parseIcs(expectedAliceIcs);
-
-        awaitAtMost.untilAsserted(() -> {
-            Calendar actualAliceCalendar = CalendarUtil.parseIcsAndSanitize(
-                calDavClient.getCalendarEvent(alice, aliceCalendarEventUri),
-                IGNORED_CALENDAR_PROPERTIES);
-            assertThat(actualAliceCalendar).isEqualTo(expectedAliceCalendar);
-        });
+        awaitAtMost.untilAsserted(() ->
+            assertThatCalendar(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri))
+                .ignoringProperties(IGNORED_CALENDAR_PROPERTIES)
+                .isEqualTo(expectedAliceIcs));
     }
 
     private String awaitFirstEventId(OpenPaasUser user) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Introduced a new assertion utility for validating iCalendar content in tests with flexible comparison options.
  * Refactored test suites to streamline iCalendar validation, reducing manual normalization code and improving test maintainability.
  * Tests now support ignoring specific calendar properties and participant status during comparisons for more focused assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->