### PR TITLE
Update DomainAddressBookContract to test both XML and JSON

### DIFF
--- a/src/test/java/com/linagora/dav/CardDavClient.java
+++ b/src/test/java/com/linagora/dav/CardDavClient.java
@@ -74,8 +74,8 @@ public class CardDavClient {
         }
     }
 
-    private static final String CONTENT_TYPE_VCARD = "application/vcard";
-    private static final String ACCEPT_VCARD_JSON = "text/plain";
+    private static final String CONTENT_TYPE_VCARD = "application/vcard+json";
+    private static final String ACCEPT_VCARD_JSON = "application/json, text/plain, */*";
     private static final String ADDRESS_BOOK_PATH = "/addressbooks/%s/%s/%s.vcf";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -133,6 +133,39 @@ public class CardDavClient {
             .uri(uri)
             .responseSingle((response, buf) -> {
                 if (response.status().code() == 200) {
+                    return buf.asString(StandardCharsets.UTF_8);
+                }
+                return buf.asString(StandardCharsets.UTF_8)
+                    .switchIfEmpty(Mono.just(StringUtils.EMPTY))
+                    .flatMap(errorBody -> Mono.error(new RuntimeException(
+                        "Unexpected status code: %d when fetching contacts in address book %s for user %s\n%s"
+                            .formatted(response.status().code(), addressBookId, openPaasUser.id(), errorBody))));
+            }).block();
+    }
+
+    public String getContactsXML(OpenPaasUser openPaasUser, String baseId, String addressBookId) {
+        String payload = """
+            <?xml version="1.0" encoding="utf-8" ?>
+            <C:addressbook-query xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:carddav">
+              <D:prop>
+                <D:getetag/>
+                <C:address-data/>
+              </D:prop>
+            </C:addressbook-query>
+            """;
+        return getContactsXML(openPaasUser, baseId, addressBookId, payload);
+    }
+
+    public String getContactsXML(OpenPaasUser openPaasUser, String baseId, String addressBookId, String payload) {
+        String uri = String.format("/addressbooks/%s/%s",
+            baseId, addressBookId);
+        return client.headers(headers -> openPaasUser.impersonatedBasicAuth(headers)
+                .add("Depth", 1))
+            .request(HttpMethod.valueOf("REPORT"))
+            .uri(uri)
+            .send(Mono.just(Unpooled.wrappedBuffer(payload.getBytes(StandardCharsets.UTF_8))))
+            .responseSingle((response, buf) -> {
+                if (response.status().code() == 207) {
                     return buf.asString(StandardCharsets.UTF_8);
                 }
                 return buf.asString(StandardCharsets.UTF_8)

--- a/src/test/java/com/linagora/dav/VCardContact.java
+++ b/src/test/java/com/linagora/dav/VCardContact.java
@@ -1,0 +1,199 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.dav;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public record VCardContact(String firstName,
+                           String lastName,
+                           Optional<String> tel,
+                           Optional<String> email,
+                           Optional<String> categories,
+                           Optional<String> org,
+                           Optional<String> role) {
+
+    public static class Builder {
+        private Optional<String> firstName = Optional.empty();
+        private Optional<String> lastName = Optional.empty();
+        private Optional<String> tel = Optional.empty();
+        private Optional<String> email = Optional.empty();
+        private Optional<String> categories = Optional.empty();
+        private Optional<String> org = Optional.empty();
+        private Optional<String> role = Optional.empty();
+
+        public Builder firstName(String firstName) {
+            this.firstName = Optional.of(firstName);
+            return this;
+        }
+
+        public Builder lastName(String lastName) {
+            this.lastName = Optional.of(lastName);
+            return this;
+        }
+
+        public Builder tel(String tel) {
+            this.tel = Optional.of(tel);
+            return this;
+        }
+
+        public Builder email(String email) {
+            this.email = Optional.of(email);
+            return this;
+        }
+
+        public Builder categories(String categories) {
+            this.categories = Optional.of(categories);
+            return this;
+        }
+
+        public Builder org(String org) {
+            this.org = Optional.of(org);
+            return this;
+        }
+
+        public Builder role(String role) {
+            this.role = Optional.of(role);
+            return this;
+        }
+
+        public VCardContact build() {
+            return new VCardContact(
+                firstName.orElseThrow(() -> new IllegalArgumentException("First name is required")),
+                lastName.orElseThrow(() -> new IllegalArgumentException("Last name is required")),
+                tel,
+                email,
+                categories,
+                org,
+                role
+            );
+        }
+    }
+
+    public enum Format { VCARD, JSON }
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public byte[] toBytes(Format format, String uid) {
+        return switch (format) {
+            case VCARD -> toVCardPayload(uid);
+            case JSON -> toVCardJsonPayload(uid);
+        };
+    }
+
+    public byte[] toVCardPayload(String uid) {
+        StringBuilder vcard = new StringBuilder()
+            .append("BEGIN:VCARD\n")
+            .append("VERSION:3.0\n")
+            .append("UID:").append(uid).append("\n")
+            .append("FN:").append(firstName).append(" ").append(lastName).append("\n")
+            .append("N:").append(lastName).append(";").append(firstName).append("\n");
+        tel.ifPresent(t -> vcard.append("TEL;TYPE=WORK:").append(t).append("\n"));
+        email.ifPresent(e -> vcard.append("EMAIL;TYPE=WORK:").append(e).append("\n"));
+        org.ifPresent(o -> vcard.append("ORG:").append(o).append("\n"));
+        role.ifPresent(r -> vcard.append("ROLE:").append(r).append("\n"));
+        categories.ifPresent(c -> vcard.append("CATEGORIES:").append(c).append("\n"));
+        vcard.append("END:VCARD");
+        return vcard.toString().getBytes(StandardCharsets.UTF_8);
+    }
+
+    public byte[] toVCardJsonPayload(String uid) {
+        try {
+            ArrayNode root = OBJECT_MAPPER.createArrayNode().add("vcard");
+
+            ArrayNode nValue = OBJECT_MAPPER.createArrayNode()
+                .add(lastName)
+                .add(firstName);
+
+            ArrayNode props = OBJECT_MAPPER.createArrayNode()
+                .add(textProp("version", "3.0"))
+                .add(textProp("uid", uid))
+                .add(textProp("fn", firstName + " " + lastName))
+                .add(arrayProp("n", nValue));
+
+            tel.ifPresent(t -> {
+                ObjectNode telParams = OBJECT_MAPPER.createObjectNode();
+                ArrayNode telType = OBJECT_MAPPER.createArrayNode()
+                    .add("Work");
+                telParams.set("type", telType);
+                ArrayNode telProp = OBJECT_MAPPER.createArrayNode()
+                    .add("tel")
+                    .add(telParams)
+                    .add("uri")
+                    .add(t);
+                props.add(telProp);
+            });
+
+            email.ifPresent(e -> {
+                ObjectNode emailParams = OBJECT_MAPPER.createObjectNode();
+                ArrayNode emailType = OBJECT_MAPPER.createArrayNode()
+                    .add("Work");
+                emailParams.set("type", emailType);
+                ArrayNode emailProp = OBJECT_MAPPER.createArrayNode()
+                    .add("email")
+                    .add(emailParams)
+                    .add("text")
+                    .add(e);
+                props.add(emailProp);
+            });
+
+            categories.ifPresent(c -> props.add(textProp("categories", c)));
+
+            org.ifPresent(o -> {
+                ArrayNode orgValue = OBJECT_MAPPER.createArrayNode()
+                    .add(o);
+                props.add(arrayProp("org", orgValue));
+            });
+
+            role.ifPresent(r -> props.add(textProp("role", r)));
+
+            root.add(props);
+            root.add(OBJECT_MAPPER.createArrayNode());
+
+            return OBJECT_MAPPER.writeValueAsBytes(root);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to serialize VCardContact to jCard JSON", e);
+        }
+    }
+
+    private ArrayNode textProp(String name, String value) {
+        return OBJECT_MAPPER.createArrayNode()
+            .add(name)
+            .add(OBJECT_MAPPER.createObjectNode())
+            .add("text")
+            .add(value);
+    }
+
+    private ArrayNode arrayProp(String name, ArrayNode value) {
+        return OBJECT_MAPPER.createArrayNode()
+            .add(name)
+            .add(OBJECT_MAPPER.createObjectNode())
+            .add("text")
+            .add(value);
+    }
+}

--- a/src/test/java/com/linagora/dav/contracts/DomainAddressBookContract.java
+++ b/src/test/java/com/linagora/dav/contracts/DomainAddressBookContract.java
@@ -29,11 +29,14 @@ import org.apache.commons.lang3.StringUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import com.linagora.dav.CardDavClient;
 import com.linagora.dav.DockerTwakeCalendarExtension;
 import com.linagora.dav.DockerTwakeCalendarSetup;
 import com.linagora.dav.OpenPaasUser;
+import com.linagora.dav.VCardContact;
 
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
@@ -69,32 +72,28 @@ public abstract class DomainAddressBookContract {
             .build();
     }
 
-    @Test
-    void regularUserCanReadDomainMemberAddressBookContactsWhenInDomain() {
+    @ParameterizedTest
+    @EnumSource(VCardContact.Format.class)
+    void regularUserCanReadDomainMemberAddressBookContactsWhenInDomain(VCardContact.Format format) {
         // GIVEN a domain addressbook with two contacts
         cardDavClient.createDomainMembersAddressBook(domainId, technicalToken);
 
         String firstUid = "contact-" + UUID.randomUUID();
         String secondUid = "contact-" + UUID.randomUUID();
 
-        byte[] firstVCard = """
-            BEGIN:VCARD
-            VERSION:3.0
-            FN:First Contact
-            EMAIL:first.contact@%s
-            END:VCARD
-            """.formatted(domainId).getBytes(StandardCharsets.UTF_8);
+        VCardContact firstContact = VCardContact.builder()
+            .firstName("First")
+            .lastName("Contact")
+            .email("first.contact@" + domainId)
+            .build();
+        VCardContact secondContact = VCardContact.builder()
+            .firstName("Second")
+            .lastName("Contact")
+            .email("second.contact@" + domainId)
+            .build();
 
-        byte[] secondVCard = """
-            BEGIN:VCARD
-            VERSION:3.0
-            FN:Second Contact
-            EMAIL:second.contact@%s
-            END:VCARD
-            """.formatted(domainId).getBytes(StandardCharsets.UTF_8);
-
-        cardDavClient.upsertDomainMemberContact(domainId, firstUid, firstVCard, technicalToken);
-        cardDavClient.upsertDomainMemberContact(domainId, secondUid, secondVCard, technicalToken);
+        cardDavClient.upsertDomainMemberContact(domainId, firstUid, firstContact.toBytes(format, firstUid), technicalToken);
+        cardDavClient.upsertDomainMemberContact(domainId, secondUid, secondContact.toBytes(format, secondUid), technicalToken);
 
         // WHEN a user of that domain fetches domain-members addressbook
         String response = cardDavClient.getContacts(openPaasUser, domainId, "domain-members");
@@ -107,8 +106,43 @@ public abstract class DomainAddressBookContract {
             .contains("second.contact@" + domainId);
     }
 
-    @Test
-    void adminUserCannotAddContactIntoDomainMemberAddressBook() {
+    @ParameterizedTest
+    @EnumSource(VCardContact.Format.class)
+    void regularUserCanReadDomainMemberAddressBookContactsInXMLFormat(VCardContact.Format format) {
+        // GIVEN a domain addressbook with two contacts
+        cardDavClient.createDomainMembersAddressBook(domainId, technicalToken);
+
+        String firstUid = "contact-" + UUID.randomUUID();
+        String secondUid = "contact-" + UUID.randomUUID();
+
+        VCardContact firstContact = VCardContact.builder()
+            .firstName("First")
+            .lastName("Contact")
+            .email("first.contact@" + domainId)
+            .build();
+        VCardContact secondContact = VCardContact.builder()
+            .firstName("Second")
+            .lastName("Contact")
+            .email("second.contact@" + domainId)
+            .build();
+
+        cardDavClient.upsertDomainMemberContact(domainId, firstUid, firstContact.toBytes(format, firstUid), technicalToken);
+        cardDavClient.upsertDomainMemberContact(domainId, secondUid, secondContact.toBytes(format, secondUid), technicalToken);
+
+        // WHEN a user of that domain fetches domain-members addressbook
+        String response = cardDavClient.getContactsXML(openPaasUser, domainId, "domain-members");
+
+        // THEN they can see both contacts
+        assertThat(response)
+            .contains("First Contact")
+            .contains("Second Contact")
+            .contains("first.contact@" + domainId)
+            .contains("second.contact@" + domainId);
+    }
+
+    @ParameterizedTest
+    @EnumSource(VCardContact.Format.class)
+    void adminUserCannotAddContactIntoDomainMemberAddressBook(VCardContact.Format format) {
         OpenPaasUser adminUser = extension().newTestUser();
         String tcalendarAdminApiBase = extension().getDockerTwakeCalendarSetupSingleton()
             .getServiceUri(DockerTwakeCalendarSetup.DockerService.CALENDAR_SIDE_ADMIN, "http")
@@ -127,18 +161,16 @@ public abstract class DomainAddressBookContract {
 
         // AND a contact vCard payload
         String vcardUid = "contact-" + UUID.randomUUID();
-        byte[] vcardPayload = """
-            BEGIN:VCARD
-            VERSION:3.0
-            FN:New Contact1
-            EMAIL:contact@%s
-            END:VCARD
-            """.formatted(domainId).getBytes(StandardCharsets.UTF_8);
+        VCardContact contact = VCardContact.builder()
+            .firstName("New")
+            .lastName("Contact1")
+            .email("contact@" + domainId)
+            .build();
 
         // WHEN an administrator tries to add a contact into the domain-members addressbook
         // THEN the server rejects the request (403)
         assertThatThrownBy(() ->
-            cardDavClient.upsertContact(adminUser, domainId, "domain-members", vcardUid, vcardPayload))
+            cardDavClient.upsertContact(adminUser, domainId, "domain-members", vcardUid, contact.toBytes(format, vcardUid)))
             .isInstanceOf(RuntimeException.class)
             .hasMessageContaining("Unexpected status code: 403");
 
@@ -147,22 +179,21 @@ public abstract class DomainAddressBookContract {
             .doesNotContain("New Contact1");
     }
 
-    @Test
-    void technicalTokenCanManageDomainMemberContacts() {
+    @ParameterizedTest
+    @EnumSource(VCardContact.Format.class)
+    void technicalTokenCanManageDomainMemberContacts(VCardContact.Format format) {
         // GIVEN an empty domain addressbook created by the Twake Calendar service
         cardDavClient.createDomainMembersAddressBook(domainId, technicalToken);
 
         String vcardUid = "member-" + UUID.randomUUID();
-        byte[] vcardPayload = """
-            BEGIN:VCARD
-            VERSION:3.0
-            FN:Technical Contact
-            EMAIL:tech.contact@%s
-            END:VCARD
-            """.formatted(domainId).getBytes(StandardCharsets.UTF_8);
+        VCardContact contact = VCardContact.builder()
+            .firstName("Technical")
+            .lastName("Contact")
+            .email("tech.contact@" + domainId)
+            .build();
 
         // WHEN using the technical token to create a new domain member contact
-        cardDavClient.upsertDomainMemberContact(domainId, vcardUid, vcardPayload, technicalToken);
+        cardDavClient.upsertDomainMemberContact(domainId, vcardUid, contact.toBytes(format, vcardUid), technicalToken);
 
         // THEN the contact is visible in the addressbook
         String responseAfterCreate = cardDavClient.getContacts(openPaasUser, domainId, "domain-members");
@@ -171,14 +202,12 @@ public abstract class DomainAddressBookContract {
             .contains("tech.contact@" + domainId);
 
         // WHEN updating the same contact using the technical token
-        byte[] updatedVcardPayload = """
-            BEGIN:VCARD
-            VERSION:3.0
-            FN:Updated Contact
-            EMAIL:tech.updated@%s
-            END:VCARD
-            """.formatted(domainId).getBytes(StandardCharsets.UTF_8);
-        cardDavClient.upsertDomainMemberContact(domainId, vcardUid, updatedVcardPayload, technicalToken);
+        VCardContact updatedContact = VCardContact.builder()
+            .firstName("Updated")
+            .lastName("Contact")
+            .email("tech.updated@" + domainId)
+            .build();
+        cardDavClient.upsertDomainMemberContact(domainId, vcardUid, updatedContact.toBytes(format, vcardUid), technicalToken);
 
         // THEN the updated value is visible
         String responseAfterUpdate = cardDavClient.getContacts(openPaasUser, domainId, "domain-members");
@@ -197,8 +226,9 @@ public abstract class DomainAddressBookContract {
             .doesNotContain("tech.updated@" + domainId);
     }
 
-    @Test
-    void domainAdministratorCanAddContactToDomainAddressBook() {
+    @ParameterizedTest
+    @EnumSource(VCardContact.Format.class)
+    void domainAdministratorCanAddContactToDomainAddressBook(VCardContact.Format format) {
         String domainId = extension().domainId();
         OpenPaasUser alice = extension().newTestUser();
         OpenPaasUser bob = extension().newTestUser();
@@ -220,8 +250,11 @@ public abstract class DomainAddressBookContract {
 
         // When bob adds a contact to the domain address book
         String vcardUid = "test-contact-uid";
-        byte[] vcardPayload = "BEGIN:VCARD\nVERSION:3.0\nFN:John Doe\nEND:VCARD".getBytes(StandardCharsets.UTF_8);
-        cardDavClient.upsertContact(bob, domainId, "dab", vcardUid, vcardPayload);
+        VCardContact contact = VCardContact.builder()
+            .firstName("John")
+            .lastName("Doe")
+            .build();
+        cardDavClient.upsertContact(bob, domainId, "dab", vcardUid, contact.toBytes(format, vcardUid));
 
         String response = cardDavClient.getContacts(alice, domainId, "dab");
 
@@ -229,8 +262,9 @@ public abstract class DomainAddressBookContract {
         assertThat(response).contains("John Doe");
     }
 
-    @Test
-    void domainAdministratorCanUpdateContactInDomainAddressBook() {
+    @ParameterizedTest
+    @EnumSource(VCardContact.Format.class)
+    void domainAdministratorCanUpdateContactInDomainAddressBook(VCardContact.Format format) {
         String domainId = extension().domainId();
         OpenPaasUser alice = extension().newTestUser();
         OpenPaasUser bob = extension().newTestUser();
@@ -238,8 +272,11 @@ public abstract class DomainAddressBookContract {
         cardDavClient.createDomainAddressBook(domainId, technicalToken);
 
         String vcardUid = "test-contact-uid";
-        byte[] vcardPayload = "BEGIN:VCARD\nVERSION:3.0\nFN:John Doe\nEND:VCARD".getBytes(StandardCharsets.UTF_8);
-        cardDavClient.upsertDomainContact(domainId, vcardUid, vcardPayload, technicalToken);
+        VCardContact contact = VCardContact.builder()
+            .firstName("John")
+            .lastName("Doe")
+            .build();
+        cardDavClient.upsertDomainContact(domainId, vcardUid, contact.toBytes(format, vcardUid), technicalToken);
 
         String tcalendarAdminApiBase = extension().getDockerTwakeCalendarSetupSingleton()
             .getServiceUri(DockerTwakeCalendarSetup.DockerService.CALENDAR_SIDE_ADMIN, "http")
@@ -255,8 +292,11 @@ public abstract class DomainAddressBookContract {
             .statusCode(204);
 
         // When bob update contact in the domain address book
-        byte[] updatedVcardPayload = "BEGIN:VCARD\nVERSION:3.0\nFN:John Cole\nEND:VCARD".getBytes(StandardCharsets.UTF_8);
-        cardDavClient.upsertContact(bob, domainId, "dab", vcardUid, updatedVcardPayload);
+        VCardContact updatedContact = VCardContact.builder()
+            .firstName("John")
+            .lastName("Cole")
+            .build();
+        cardDavClient.upsertContact(bob, domainId, "dab", vcardUid, updatedContact.toBytes(format, vcardUid));
 
         String response = cardDavClient.getContacts(alice, domainId, "dab");
 
@@ -273,8 +313,11 @@ public abstract class DomainAddressBookContract {
         cardDavClient.createDomainAddressBook(domainId, technicalToken);
 
         String vcardUid = "test-contact-uid";
-        byte[] vcardPayload = "BEGIN:VCARD\nVERSION:3.0\nFN:John Doe\nEND:VCARD".getBytes(StandardCharsets.UTF_8);
-        cardDavClient.upsertDomainContact(domainId, vcardUid, vcardPayload, technicalToken);
+        VCardContact contact = VCardContact.builder()
+            .firstName("John")
+            .lastName("Doe")
+            .build();
+        cardDavClient.upsertDomainContact(domainId, vcardUid, contact.toVCardJsonPayload(vcardUid), technicalToken);
 
         String tcalendarAdminApiBase = extension().getDockerTwakeCalendarSetupSingleton()
             .getServiceUri(DockerTwakeCalendarSetup.DockerService.CALENDAR_SIDE_ADMIN, "http")
@@ -298,17 +341,21 @@ public abstract class DomainAddressBookContract {
         assertThat(response).doesNotContain("John Doe");
     }
 
-    @Test
-    void normalUserCannotAddContactToDomainAddressBook() {
+    @ParameterizedTest
+    @EnumSource(VCardContact.Format.class)
+    void normalUserCannotAddContactToDomainAddressBook(VCardContact.Format format) {
         String domainId = extension().domainId();
         OpenPaasUser bob = extension().newTestUser();
 
         cardDavClient.createDomainAddressBook(domainId, technicalToken);
 
         String vcardUid = "test-contact-uid";
-        byte[] vcardPayload = "BEGIN:VCARD\nVERSION:3.0\nFN:John Doe\nEND:VCARD".getBytes(StandardCharsets.UTF_8);
+        VCardContact contact = VCardContact.builder()
+            .firstName("John")
+            .lastName("Doe")
+            .build();
 
-        Assertions.assertThatThrownBy(() -> cardDavClient.upsertContact(bob, domainId, "dab", vcardUid, vcardPayload))
+        Assertions.assertThatThrownBy(() -> cardDavClient.upsertContact(bob, domainId, "dab", vcardUid, contact.toBytes(format, vcardUid)))
             .hasMessageContaining("Unexpected status code: 403");
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for returning contacts as either vCard or JSON payloads.
  * Added API to fetch address-book contacts using CardDAV REPORT queries.

* **Bug Fixes**
  * Improved content-type and accept handling for vCard/JSON negotiations.

* **Tests**
  * Parameterized tests now validate contact operations for both vCard and JSON formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->