### PR TITLE
test(calendar-sharing): stabilize iTIP CANCEL test with AMQP scheduling

### DIFF
--- a/src/test/java/com/linagora/dav/contracts/cal/CalendarSharingContract.java
+++ b/src/test/java/com/linagora/dav/contracts/cal/CalendarSharingContract.java
@@ -1594,6 +1594,33 @@ public abstract class CalendarSharingContract {
         assertThat(aliceEventsBefore).hasSize(1);
 
         String eventHref = aliceEventsBefore.getFirst().path("_links").path("self").path("href").asText();
+        List<OpenPaasUser> attendees = List.of(alice, cedric);
+
+        // AND: Initial iTIP REQUEST deliveries are completed before deleting the event
+        for (OpenPaasUser attendee : attendees) {
+            String inboxUri = "/calendars/" + attendee.id() + "/inbox/";
+            awaitAtMost.untilAsserted(() -> {
+                List<JsonNode> inboxItems = calDavClient.reportCalendarEvents(
+                        attendee,
+                        inboxUri,
+                        Instant.parse("2025-09-01T00:00:00Z"),
+                        Instant.parse("2025-11-01T00:00:00Z"))
+                    .collectList().block();
+
+                assertThat(inboxItems)
+                    .anySatisfy(item -> {
+                        String json = item.toString();
+                        assertThat(json).contains(eventUid);
+                        assertThat(json).contains("mailto:" + attendee.email());
+                        assertThatJson(item)
+                            .inPath("data[1]")
+                            .isArray()
+                            .anySatisfy(node -> assertThatJson(MAPPER.writeValueAsString(node))
+                                .isEqualTo("""
+                                    ["method", {}, "text", "REQUEST"]"""));
+                    });
+            });
+        }
 
         // WHEN: Alice deletes the event from her subscribed copy
         calDavClient.deleteCalendarEvent(alice, URI.create(eventHref));
@@ -1609,8 +1636,6 @@ public abstract class CalendarSharingContract {
         assertThat(bobEventsAfter).isEmpty();
 
         // AND: Both Alice and Cedric should receive an iTIP CANCEL request
-        List<OpenPaasUser> attendees = List.of(alice, cedric);
-
         for (OpenPaasUser attendee : attendees) {
             String inboxUri = "/calendars/" + attendee.id() + "/inbox/";
             awaitAtMost.untilAsserted(() -> {


### PR DESCRIPTION
CI fail: https://james-jenkins.lin-saas.com/job/Calendar%20Integration%20Tests%20build/job/master/130/testReport/

The test `triggersITIPCancelWhenEventDeleted` was flaky with -Damqp.scheduling.enabled=true due to async race between initial iTIP REQUEST delivery and subsequent DELETE/CANCEL flow.

Wait for initial REQUEST to be observable in attendee inboxes before deleting the event, then assert CANCEL as before. This keeps behavior unchanged while making the test deterministic under async scheduling.