### PR TITLE
test(scheduling): assert attendee PUT update does not propagate to organizer/other attendees

### DIFF
--- a/src/test/java/com/linagora/dav/CalendarUtil.java
+++ b/src/test/java/com/linagora/dav/CalendarUtil.java
@@ -158,6 +158,18 @@ public class CalendarUtil {
         });
     }
 
+    public static String getOrganizer(String icsContent) {
+        return getOrganizer(parseIcs(icsContent));
+    }
+
+    public static String getOrganizer(Calendar calendar) {
+        return calendar.getComponents(Component.VEVENT).stream()
+            .flatMap(vevent -> vevent.getProperties(Property.ORGANIZER).stream())
+            .map(Property::getValue)
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Organizer not found in calendar"));
+    }
+
     public static PartStat getAttendeePartStat(String icsContent, String attendeeEmail) {
         return getAttendeePartStat(parseIcs(icsContent), attendeeEmail);
     }

--- a/src/test/java/com/linagora/dav/CalendarUtil.java
+++ b/src/test/java/com/linagora/dav/CalendarUtil.java
@@ -158,18 +158,6 @@ public class CalendarUtil {
         });
     }
 
-    public static String getOrganizer(String icsContent) {
-        return getOrganizer(parseIcs(icsContent));
-    }
-
-    public static String getOrganizer(Calendar calendar) {
-        return calendar.getComponents(Component.VEVENT).stream()
-            .flatMap(vevent -> vevent.getProperties(Property.ORGANIZER).stream())
-            .map(Property::getValue)
-            .findFirst()
-            .orElseThrow(() -> new AssertionError("Organizer not found in calendar"));
-    }
-
     public static PartStat getAttendeePartStat(String icsContent, String attendeeEmail) {
         return getAttendeePartStat(parseIcs(icsContent), attendeeEmail);
     }

--- a/src/test/java/com/linagora/dav/contracts/cal/SchedulingContract.java
+++ b/src/test/java/com/linagora/dav/contracts/cal/SchedulingContract.java
@@ -46,6 +46,7 @@ import com.linagora.dav.DockerTwakeCalendarExtension;
 import com.linagora.dav.OpenPaasUser;
 
 import net.fortuna.ical4j.model.Calendar;
+import net.fortuna.ical4j.model.Component;
 import net.fortuna.ical4j.model.Property;
 import net.fortuna.ical4j.model.parameter.PartStat;
 import net.fortuna.ical4j.model.property.Transp;
@@ -1301,6 +1302,134 @@ public abstract class SchedulingContract {
                     .isEqualTo(PartStat.ACCEPTED);
                 assertThat(CalendarUtil.getAttendeePartStat(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri), bob.email()))
                     .isEqualTo(PartStat.ACCEPTED);
+            });
+    }
+
+    @Test
+    void attendeeUpdatingOtherAttendeeParticipationShouldNotPropagateToOrganizerAndTargetAttendee() {
+        // Given Bob creates an event with Alice and Cedric as attendees
+        String organizerEventUid = "event-" + UUID.randomUUID();
+        String organizerEventIcs = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Example Corp.//CalDAV Client//EN
+            BEGIN:VEVENT
+            UID:{organizerEventUid}
+            DTSTAMP:20351003T080000Z
+            DTSTART:20351005T090000Z
+            DTEND:20351005T100000Z
+            SUMMARY:Participation isolation check for target attendee
+            ORGANIZER:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=ACCEPTED;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:{aliceEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:{cedricEmail}
+            END:VEVENT
+            END:VCALENDAR
+            """
+            .replace("{organizerEventUid}", organizerEventUid)
+            .replace("{bobEmail}", bob.email())
+            .replace("{aliceEmail}", alice.email())
+            .replace("{cedricEmail}", cedric.email());
+        calDavClient.upsertCalendarEvent(bob, organizerEventUid, organizerEventIcs);
+
+        String aliceCalendarEventId = awaitFirstEventId(alice);
+        String cedricCalendarEventId = awaitFirstEventId(cedric);
+        URI aliceCalendarEventUri = URI.create("/calendars/" + alice.id() + "/" + alice.id() + "/" + aliceCalendarEventId + ".ics");
+        URI cedricCalendarEventUri = URI.create("/calendars/" + cedric.id() + "/" + cedric.id() + "/" + cedricCalendarEventId + ".ics");
+        URI bobCalendarEventUri = URI.create("/calendars/" + bob.id() + "/" + bob.id() + "/" + organizerEventUid + ".ics");
+
+        awaitAtMost.untilAsserted(() -> {
+            assertThat(CalendarUtil.toExtractor(calDavClient.getCalendarEvent(bob, bobCalendarEventUri))
+                .extractAttendeePartStat(cedric.email()))
+                .isEqualTo(PartStat.NEEDS_ACTION);
+            assertThat(CalendarUtil.toExtractor(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri))
+                .extractAttendeePartStat(cedric.email()))
+                .isEqualTo(PartStat.NEEDS_ACTION);
+        });
+
+        // When Alice changes Cedric PARTSTAT in her own event copy
+        String aliceCalendarEventIcs = calDavClient.getCalendarEvent(alice, aliceCalendarEventUri);
+        String aliceUpdatedCalendarEventIcs = CalendarUtil.withAttendeePartStat(aliceCalendarEventIcs, cedric.email(), PartStat.ACCEPTED);
+        calDavClient.upsertCalendarEvent(alice, aliceCalendarEventUri, aliceUpdatedCalendarEventIcs);
+
+        // Then Bob and Cedric calendars keep Cedric participation untouched
+        calmlyAwait
+            .during(2, TimeUnit.SECONDS)
+            .untilAsserted(() -> {
+                assertThat(CalendarUtil.toExtractor(calDavClient.getCalendarEvent(bob, bobCalendarEventUri))
+                    .extractAttendeePartStat(cedric.email()))
+                    .isEqualTo(PartStat.NEEDS_ACTION);
+                assertThat(CalendarUtil.toExtractor(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri))
+                    .extractAttendeePartStat(cedric.email()))
+                    .isEqualTo(PartStat.NEEDS_ACTION);
+            });
+    }
+
+    @Test
+    void attendeeRemovingOtherAttendeeShouldNotPropagateToOrganizerAndOtherAttendees() {
+        // Given Bob creates an event with Alice and Cedric as attendees
+        String organizerEventUid = "event-" + UUID.randomUUID();
+        String organizerEventIcs = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Example Corp.//CalDAV Client//EN
+            BEGIN:VEVENT
+            UID:{organizerEventUid}
+            DTSTAMP:20351003T080000Z
+            DTSTART:20351005T090000Z
+            DTEND:20351005T100000Z
+            SUMMARY:Remove attendee isolation check
+            ORGANIZER:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=ACCEPTED;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:{aliceEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:{cedricEmail}
+            END:VEVENT
+            END:VCALENDAR
+            """
+            .replace("{organizerEventUid}", organizerEventUid)
+            .replace("{bobEmail}", bob.email())
+            .replace("{aliceEmail}", alice.email())
+            .replace("{cedricEmail}", cedric.email());
+        calDavClient.upsertCalendarEvent(bob, organizerEventUid, organizerEventIcs);
+
+        String aliceCalendarEventId = awaitFirstEventId(alice);
+        String cedricCalendarEventId = awaitFirstEventId(cedric);
+        URI aliceCalendarEventUri = URI.create("/calendars/" + alice.id() + "/" + alice.id() + "/" + aliceCalendarEventId + ".ics");
+        URI cedricCalendarEventUri = URI.create("/calendars/" + cedric.id() + "/" + cedric.id() + "/" + cedricCalendarEventId + ".ics");
+        URI bobCalendarEventUri = URI.create("/calendars/" + bob.id() + "/" + bob.id() + "/" + organizerEventUid + ".ics");
+
+        awaitAtMost.untilAsserted(() -> {
+            assertThat(CalendarUtil.toExtractor(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri))
+                .extractAttendeePartStat(cedric.email()))
+                .isEqualTo(PartStat.NEEDS_ACTION);
+            assertThat(CalendarUtil.toExtractor(calDavClient.getCalendarEvent(bob, bobCalendarEventUri))
+                .extractAttendeePartStat(cedric.email()))
+                .isEqualTo(PartStat.NEEDS_ACTION);
+            assertThat(CalendarUtil.toExtractor(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri))
+                .extractAttendeePartStat(cedric.email()))
+                .isEqualTo(PartStat.NEEDS_ACTION);
+        });
+
+        // When Alice removes Cedric from her own event copy
+        String aliceCalendarEventIcs = calDavClient.getCalendarEvent(alice, aliceCalendarEventUri);
+        Calendar aliceCalendar = CalendarUtil.parseIcs(aliceCalendarEventIcs);
+        aliceCalendar.getComponents(Component.VEVENT).forEach(vevent -> vevent.getProperties(Property.ATTENDEE).stream()
+            .filter(attendee -> ("mailto:" + cedric.email()).equalsIgnoreCase(attendee.getValue()))
+            .toList()
+            .forEach(vevent::remove));
+        String aliceUpdatedCalendarEventIcs = aliceCalendar.toString();
+        calDavClient.upsertCalendarEvent(alice, aliceCalendarEventUri, aliceUpdatedCalendarEventIcs);
+
+        // Then Bob and Cedric calendars keep Cedric attendee untouched
+        calmlyAwait
+            .during(2, TimeUnit.SECONDS)
+            .untilAsserted(() -> {
+                assertThat(CalendarUtil.toExtractor(calDavClient.getCalendarEvent(bob, bobCalendarEventUri))
+                    .extractAttendeePartStat(cedric.email()))
+                    .isEqualTo(PartStat.NEEDS_ACTION);
+                assertThat(CalendarUtil.toExtractor(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri))
+                    .extractAttendeePartStat(cedric.email()))
+                    .isEqualTo(PartStat.NEEDS_ACTION);
             });
     }
 

--- a/src/test/java/com/linagora/dav/contracts/cal/SchedulingContract.java
+++ b/src/test/java/com/linagora/dav/contracts/cal/SchedulingContract.java
@@ -834,6 +834,13 @@ public abstract class SchedulingContract {
         return Stream.concat(coreEventPropertyUpdates(), recurringOnlyPropertyUpdates());
     }
 
+    static Stream<PropertyChange> recurringOverridePropertyUpdates() {
+        return Stream.of(
+            new PropertyChange(Property.SUMMARY, "Occurrence from organizer", "Alice local occurrence"),
+            new PropertyChange(Property.DTSTART, "20351006T130000Z", "20351006T133000Z"),
+            new PropertyChange(Property.DTEND, "20351006T140000Z", "20351006T160000Z"));
+    }
+
     @ParameterizedTest(name = "[{index}] attendee updating {0} should not propagate to organizer and other attendees")
     @MethodSource("coreEventPropertyUpdates")
     void attendeePUTUpdateShouldNotPropagateToOrganizerAndOtherAttendees(PropertyChange change) {
@@ -972,6 +979,272 @@ public abstract class SchedulingContract {
                 assertThat(CalendarUtil.toExtractor(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri))
                     .extractPropertyValue(changedPropertyName))
                     .isEqualTo(originalPropertyValue);
+            });
+    }
+
+    @ParameterizedTest(name = "[{index}] attendee updating existing override {0} should not propagate to organizer and other attendees")
+    @MethodSource("recurringOverridePropertyUpdates")
+    void attendeeUpdatingExistingOverrideShouldNotPropagateToOrganizerAndOtherAttendees(PropertyChange change) {
+        // Given Bob creates a recurring event with one override and invites Alice and Cedric
+        String organizerEventUid = "event-" + UUID.randomUUID();
+        String overrideRecurrenceIdLine = "RECURRENCE-ID:20351006T090000Z";
+        String organizerEventIcs = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Example Corp.//CalDAV Client//EN
+            BEGIN:VEVENT
+            UID:{organizerEventUid}
+            DTSTAMP:20351003T080000Z
+            DTSTART:20351005T090000Z
+            DTEND:20351005T100000Z
+            RRULE:FREQ=DAILY;COUNT=4
+            SUMMARY:Master shared title
+            ORGANIZER:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=ACCEPTED;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:{aliceEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:{cedricEmail}
+            END:VEVENT
+            BEGIN:VEVENT
+            UID:{organizerEventUid}
+            {overrideRecurrenceIdLine}
+            DTSTAMP:20351003T090000Z
+            DTSTART:20351006T130000Z
+            DTEND:20351006T140000Z
+            SUMMARY:Occurrence from organizer
+            ORGANIZER:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=ACCEPTED;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:{aliceEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:{cedricEmail}
+            END:VEVENT
+            END:VCALENDAR
+            """
+            .replace("{organizerEventUid}", organizerEventUid)
+            .replace("{overrideRecurrenceIdLine}", overrideRecurrenceIdLine)
+            .replace("{bobEmail}", bob.email())
+            .replace("{aliceEmail}", alice.email())
+            .replace("{cedricEmail}", cedric.email());
+        calDavClient.upsertCalendarEvent(bob, organizerEventUid, organizerEventIcs);
+
+        String aliceCalendarEventId = awaitFirstEventId(alice);
+        String cedricCalendarEventId = awaitFirstEventId(cedric);
+        URI aliceCalendarEventUri = URI.create("/calendars/" + alice.id() + "/" + alice.id() + "/" + aliceCalendarEventId + ".ics");
+        URI cedricCalendarEventUri = URI.create("/calendars/" + cedric.id() + "/" + cedric.id() + "/" + cedricCalendarEventId + ".ics");
+        URI bobCalendarEventUri = URI.create("/calendars/" + bob.id() + "/" + bob.id() + "/" + organizerEventUid + ".ics");
+        String originalLine = change.originalLine();
+        String updatedLine = change.updatedLine();
+
+        awaitAtMost.untilAsserted(() -> assertThat(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri))
+            .contains(overrideRecurrenceIdLine)
+            .contains(originalLine));
+
+        // When Alice updates the existing override in her own copy
+        String aliceCalendarEventIcs = calDavClient.getCalendarEvent(alice, aliceCalendarEventUri);
+        String aliceUpdatedCalendarEventIcs = aliceCalendarEventIcs
+            .replace(originalLine, updatedLine);
+        calDavClient.upsertCalendarEvent(alice, aliceCalendarEventUri, aliceUpdatedCalendarEventIcs);
+
+        awaitAtMost.untilAsserted(() -> assertThat(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri))
+            .contains(overrideRecurrenceIdLine)
+            .contains(updatedLine));
+
+        // Then Bob and Cedric calendars keep organizer override unchanged
+        calmlyAwait
+            .during(2, TimeUnit.SECONDS)
+            .untilAsserted(() -> {
+                assertThat(calDavClient.getCalendarEvent(bob, bobCalendarEventUri))
+                    .contains(overrideRecurrenceIdLine)
+                    .contains(originalLine)
+                    .doesNotContain(updatedLine);
+
+                assertThat(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri))
+                    .contains(overrideRecurrenceIdLine)
+                    .contains(originalLine)
+                    .doesNotContain(updatedLine);
+            });
+    }
+
+    @Disabled("esn-sabre issue https://github.com/linagora/esn-sabre/issues/322")
+    @Test
+    void attendeeCreatingNewOverrideShouldNotPropagateToOrganizerAndOtherAttendees() {
+        // Given Bob creates a recurring master event (no override) and invites Alice and Cedric
+        String organizerEventUid = "event-" + UUID.randomUUID();
+        String overrideRecurrenceIdLine = "RECURRENCE-ID:20351006T090000Z";
+        String aliceLocalOverrideSummaryLine = "SUMMARY:Alice new local override";
+        String organizerEventIcs = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Example Corp.//CalDAV Client//EN
+            BEGIN:VEVENT
+            UID:{organizerEventUid}
+            DTSTAMP:20351003T080000Z
+            DTSTART:20351005T090000Z
+            DTEND:20351005T100000Z
+            RRULE:FREQ=DAILY;COUNT=4
+            SUMMARY:Master shared title
+            ORGANIZER:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=ACCEPTED;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:{aliceEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:{cedricEmail}
+            END:VEVENT
+            END:VCALENDAR
+            """
+            .replace("{organizerEventUid}", organizerEventUid)
+            .replace("{bobEmail}", bob.email())
+            .replace("{aliceEmail}", alice.email())
+            .replace("{cedricEmail}", cedric.email());
+        calDavClient.upsertCalendarEvent(bob, organizerEventUid, organizerEventIcs);
+
+        String aliceCalendarEventId = awaitFirstEventId(alice);
+        String cedricCalendarEventId = awaitFirstEventId(cedric);
+        URI aliceCalendarEventUri = URI.create("/calendars/" + alice.id() + "/" + alice.id() + "/" + aliceCalendarEventId + ".ics");
+        URI cedricCalendarEventUri = URI.create("/calendars/" + cedric.id() + "/" + cedric.id() + "/" + cedricCalendarEventId + ".ics");
+        URI bobCalendarEventUri = URI.create("/calendars/" + bob.id() + "/" + bob.id() + "/" + organizerEventUid + ".ics");
+
+        awaitAtMost.untilAsserted(() -> {
+            assertThat(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri))
+                .doesNotContain(overrideRecurrenceIdLine);
+            assertThat(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri))
+                .doesNotContain(overrideRecurrenceIdLine);
+        });
+
+        // When Alice creates a new override occurrence in her own copy
+        String aliceCalendarEventIcs = calDavClient.getCalendarEvent(alice, aliceCalendarEventUri);
+        String aliceUpdatedCalendarEventIcs = aliceCalendarEventIcs.replace(
+            "END:VCALENDAR",
+            """
+                BEGIN:VEVENT
+                UID:{organizerEventUid}
+                RECURRENCE-ID:20351006T090000Z
+                DTSTAMP:20351003T090000Z
+                DTSTART:20351006T150000Z
+                DTEND:20351006T160000Z
+                {aliceLocalOverrideSummaryLine}
+                ORGANIZER:mailto:{bobEmail}
+                ATTENDEE;PARTSTAT=ACCEPTED;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:{bobEmail}
+                ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:{aliceEmail}
+                ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:{cedricEmail}
+                END:VEVENT
+                END:VCALENDAR
+                """
+                .replace("{organizerEventUid}", organizerEventUid)
+                .replace("{aliceLocalOverrideSummaryLine}", aliceLocalOverrideSummaryLine)
+                .replace("{bobEmail}", bob.email())
+                .replace("{aliceEmail}", alice.email())
+                .replace("{cedricEmail}", cedric.email()));
+        calDavClient.upsertCalendarEvent(alice, aliceCalendarEventUri, aliceUpdatedCalendarEventIcs);
+
+        awaitAtMost.untilAsserted(() -> assertThat(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri))
+            .contains(overrideRecurrenceIdLine)
+            .contains(aliceLocalOverrideSummaryLine));
+
+        // Then Bob and Cedric calendars keep no override occurrence
+        calmlyAwait
+            .during(2, TimeUnit.SECONDS)
+            .untilAsserted(() -> {
+                assertThat(calDavClient.getCalendarEvent(bob, bobCalendarEventUri))
+                    .doesNotContain(overrideRecurrenceIdLine)
+                    .doesNotContain(aliceLocalOverrideSummaryLine);
+                assertThat(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri))
+                    .doesNotContain(overrideRecurrenceIdLine)
+                    .doesNotContain(aliceLocalOverrideSummaryLine);
+            });
+    }
+
+    @Test
+    void attendeeRemovingExistingOverrideShouldNotPropagateToOrganizerAndOtherAttendees() {
+        // Given Bob creates a recurring event with one override and invites Alice and Cedric
+        String organizerEventUid = "event-" + UUID.randomUUID();
+        String overrideRecurrenceIdLine = "RECURRENCE-ID:20351006T090000Z";
+        String masterSummary = "Master shared title";
+        String organizerEventIcsWithOverride = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Example Corp.//CalDAV Client//EN
+            BEGIN:VEVENT
+            UID:{organizerEventUid}
+            DTSTAMP:20351003T080000Z
+            DTSTART:20351005T090000Z
+            DTEND:20351005T100000Z
+            RRULE:FREQ=DAILY;COUNT=4
+            SUMMARY:{masterSummary}
+            ORGANIZER:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=ACCEPTED;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:{aliceEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:{cedricEmail}
+            END:VEVENT
+            BEGIN:VEVENT
+            UID:{organizerEventUid}
+            {overrideRecurrenceIdLine}
+            DTSTAMP:20351003T090000Z
+            DTSTART:20351006T130000Z
+            DTEND:20351006T140000Z
+            SUMMARY:Occurrence from organizer
+            ORGANIZER:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=ACCEPTED;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:{aliceEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:{cedricEmail}
+            END:VEVENT
+            END:VCALENDAR
+            """
+            .replace("{organizerEventUid}", organizerEventUid)
+            .replace("{overrideRecurrenceIdLine}", overrideRecurrenceIdLine)
+            .replace("{masterSummary}", masterSummary)
+            .replace("{bobEmail}", bob.email())
+            .replace("{aliceEmail}", alice.email())
+            .replace("{cedricEmail}", cedric.email());
+        calDavClient.upsertCalendarEvent(bob, organizerEventUid, organizerEventIcsWithOverride);
+
+        String aliceCalendarEventId = awaitFirstEventId(alice);
+        String cedricCalendarEventId = awaitFirstEventId(cedric);
+        URI aliceCalendarEventUri = URI.create("/calendars/" + alice.id() + "/" + alice.id() + "/" + aliceCalendarEventId + ".ics");
+        URI cedricCalendarEventUri = URI.create("/calendars/" + cedric.id() + "/" + cedric.id() + "/" + cedricCalendarEventId + ".ics");
+        URI bobCalendarEventUri = URI.create("/calendars/" + bob.id() + "/" + bob.id() + "/" + organizerEventUid + ".ics");
+
+        awaitAtMost.untilAsserted(() -> assertThat(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri))
+            .contains(overrideRecurrenceIdLine)
+            .contains("SUMMARY:Occurrence from organizer"));
+
+        // When Alice removes the existing override from her own copy
+        String aliceMasterOnlyIcs = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Example Corp.//CalDAV Client//EN
+            BEGIN:VEVENT
+            UID:{organizerEventUid}
+            DTSTAMP:20351003T100000Z
+            DTSTART:20351005T090000Z
+            DTEND:20351005T100000Z
+            RRULE:FREQ=DAILY;COUNT=4
+            SUMMARY:{masterSummary}
+            ORGANIZER:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=ACCEPTED;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:{aliceEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:{cedricEmail}
+            END:VEVENT
+            END:VCALENDAR
+            """
+            .replace("{organizerEventUid}", organizerEventUid)
+            .replace("{masterSummary}", masterSummary)
+            .replace("{bobEmail}", bob.email())
+            .replace("{aliceEmail}", alice.email())
+            .replace("{cedricEmail}", cedric.email());
+        calDavClient.upsertCalendarEvent(alice, aliceCalendarEventUri, aliceMasterOnlyIcs);
+
+        awaitAtMost.untilAsserted(() -> assertThat(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri))
+            .doesNotContain(overrideRecurrenceIdLine)
+            .doesNotContain("SUMMARY:Occurrence from organizer")
+            .contains("SUMMARY:" + masterSummary));
+
+        // Then Bob and Cedric calendars keep organizer override unchanged
+        calmlyAwait
+            .during(2, TimeUnit.SECONDS)
+            .untilAsserted(() -> {
+                assertThat(calDavClient.getCalendarEvent(bob, bobCalendarEventUri))
+                    .contains(overrideRecurrenceIdLine)
+                    .contains("SUMMARY:Occurrence from organizer");
+                assertThat(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri))
+                    .contains(overrideRecurrenceIdLine)
+                    .contains("SUMMARY:Occurrence from organizer");
             });
     }
 

--- a/src/test/java/com/linagora/dav/contracts/cal/SchedulingContract.java
+++ b/src/test/java/com/linagora/dav/contracts/cal/SchedulingContract.java
@@ -823,6 +823,17 @@ public abstract class SchedulingContract {
             new PropertyChange(Property.LOCATION, "Room A", "Room B"));
     }
 
+    static Stream<PropertyChange> recurringOnlyPropertyUpdates() {
+        return Stream.of(
+            new PropertyChange(Property.RRULE, "FREQ=DAILY;COUNT=5", "FREQ=DAILY;COUNT=6"),
+            new PropertyChange(Property.RDATE, "20351011T090000Z", "20351012T090000Z"),
+            new PropertyChange(Property.EXDATE, "20351007T090000Z", "20351008T090000Z"));
+    }
+
+    static Stream<PropertyChange> recurringMasterPropertyUpdates() {
+        return Stream.concat(coreEventPropertyUpdates(), recurringOnlyPropertyUpdates());
+    }
+
     @ParameterizedTest(name = "[{index}] attendee updating {0} should not propagate to organizer and other attendees")
     @MethodSource("coreEventPropertyUpdates")
     void attendeePUTUpdateShouldNotPropagateToOrganizerAndOtherAttendees(PropertyChange change) {
@@ -879,6 +890,78 @@ public abstract class SchedulingContract {
             .isEqualTo(updatedPropertyValue));
 
         // Then Bob and Cedric calendars keep organizer values unchanged
+        calmlyAwait
+            .during(2, TimeUnit.SECONDS)
+            .untilAsserted(() -> {
+                assertThat(CalendarUtil.toExtractor(calDavClient.getCalendarEvent(bob, bobCalendarEventUri))
+                    .extractPropertyValue(changedPropertyName))
+                    .isEqualTo(originalPropertyValue);
+
+                assertThat(CalendarUtil.toExtractor(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri))
+                    .extractPropertyValue(changedPropertyName))
+                    .isEqualTo(originalPropertyValue);
+            });
+    }
+
+    @ParameterizedTest(name = "[{index}] attendee updating recurring master {0} should not propagate to organizer and other attendees")
+    @MethodSource("recurringMasterPropertyUpdates")
+    void attendeePUTUpdateOnRecurringShouldNotPropagateToOrganizerAndOtherAttendees(PropertyChange change) {
+        // Given Bob creates a recurring master event (no overrides) with Alice and Cedric as attendees
+        String organizerEventUid = "event-" + UUID.randomUUID();
+        String organizerEventIcs = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Example Corp.//CalDAV Client//EN
+            BEGIN:VEVENT
+            UID:{organizerEventUid}
+            DTSTAMP:20351003T080000Z
+            DTSTART:20351005T090000Z
+            DTEND:20351005T100000Z
+            SUMMARY:Shared title
+            DESCRIPTION:Shared description
+            CLASS:PUBLIC
+            LOCATION:Room A
+            STATUS:CONFIRMED
+            RRULE:FREQ=DAILY;COUNT=5
+            RDATE:20351011T090000Z
+            EXDATE:20351007T090000Z
+            ORGANIZER:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=ACCEPTED;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:{aliceEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:{cedricEmail}
+            END:VEVENT
+            END:VCALENDAR
+            """
+            .replace("{organizerEventUid}", organizerEventUid)
+            .replace("{bobEmail}", bob.email())
+            .replace("{aliceEmail}", alice.email())
+            .replace("{cedricEmail}", cedric.email());
+        calDavClient.upsertCalendarEvent(bob, organizerEventUid, organizerEventIcs);
+
+        String aliceCalendarEventId = awaitFirstEventId(alice);
+        String cedricCalendarEventId = awaitFirstEventId(cedric);
+        URI aliceCalendarEventUri = URI.create("/calendars/" + alice.id() + "/" + alice.id() + "/" + aliceCalendarEventId + ".ics");
+        URI cedricCalendarEventUri = URI.create("/calendars/" + cedric.id() + "/" + cedric.id() + "/" + cedricCalendarEventId + ".ics");
+        URI bobCalendarEventUri = URI.create("/calendars/" + bob.id() + "/" + bob.id() + "/" + organizerEventUid + ".ics");
+        String changedPropertyName = change.propertyName();
+        String originalPropertyValue = change.originalValue();
+        String updatedPropertyValue = change.updatedValue();
+
+        awaitAtMost.untilAsserted(() -> assertThat(CalendarUtil.toExtractor(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri))
+            .extractPropertyValue(changedPropertyName))
+            .isEqualTo(originalPropertyValue));
+
+        // When Alice updates property in her recurring master copy via HTTP PUT
+        String aliceCalendarEventIcs = calDavClient.getCalendarEvent(alice, aliceCalendarEventUri);
+        String aliceUpdatedCalendarEventIcs = aliceCalendarEventIcs
+            .replace(change.originalLine(), change.updatedLine());
+        calDavClient.upsertCalendarEvent(alice, aliceCalendarEventUri, aliceUpdatedCalendarEventIcs);
+
+        awaitAtMost.untilAsserted(() -> assertThat(CalendarUtil.toExtractor(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri))
+            .extractPropertyValue(changedPropertyName))
+            .isEqualTo(updatedPropertyValue));
+
+        // Then Bob and Cedric recurring master events keep organizer values unchanged
         calmlyAwait
             .during(2, TimeUnit.SECONDS)
             .untilAsserted(() -> {

--- a/src/test/java/com/linagora/dav/contracts/cal/SchedulingContract.java
+++ b/src/test/java/com/linagora/dav/contracts/cal/SchedulingContract.java
@@ -75,6 +75,7 @@ public abstract class SchedulingContract {
     private OpenPaasUser bob;
     private OpenPaasUser alice;
     private OpenPaasUser cedric;
+    private OpenPaasUser david;
 
     @BeforeEach
     void setUp() {
@@ -82,6 +83,7 @@ public abstract class SchedulingContract {
         bob = extension().newTestUser();
         alice = extension().newTestUser();
         cedric = extension().newTestUser();
+        david = extension().newTestUser();
     }
 
     @Test
@@ -791,6 +793,248 @@ public abstract class SchedulingContract {
         // And Alice local TRANSP is not reset by that attendee update
         assertThat(aliceCalendarEvent.get().extractPropertyValue(Property.TRANSP))
             .isEqualTo(TRANSP_TRANSPARENT);
+    }
+
+    @Test
+    void attendeePUTUpdateShouldNotPropagateToOrganizerAndOtherAttendees() {
+        // Given Bob creates an event with Alice and Cedric as attendees
+        String organizerEventUid = "event-" + UUID.randomUUID();
+        String initialSummary = "Planning meeting";
+        String initialDescription = "Initial note from Bob";
+        String organizerEventIcs = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Example Corp.//CalDAV Client//EN
+            BEGIN:VEVENT
+            UID:{organizerEventUid}
+            DTSTAMP:20351003T080000Z
+            DTSTART:20351005T090000Z
+            DTEND:20351005T100000Z
+            SUMMARY:{summary}
+            DESCRIPTION:{description}
+            ORGANIZER:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=ACCEPTED;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:{aliceEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:{cedricEmail}
+            END:VEVENT
+            END:VCALENDAR
+            """
+            .replace("{organizerEventUid}", organizerEventUid)
+            .replace("{summary}", initialSummary)
+            .replace("{description}", initialDescription)
+            .replace("{bobEmail}", bob.email())
+            .replace("{aliceEmail}", alice.email())
+            .replace("{cedricEmail}", cedric.email());
+        calDavClient.upsertCalendarEvent(bob, organizerEventUid, organizerEventIcs);
+
+        String aliceCalendarEventId = awaitFirstEventId(alice);
+        String cedricCalendarEventId = awaitFirstEventId(cedric);
+
+        // And both attendees can already see the invited event
+        URI aliceCalendarEventUri = URI.create("/calendars/" + alice.id() + "/" + alice.id() + "/" + aliceCalendarEventId + ".ics");
+        URI cedricCalendarEventUri = URI.create("/calendars/" + cedric.id() + "/" + cedric.id() + "/" + cedricCalendarEventId + ".ics");
+
+        awaitAtMost.untilAsserted(() -> {
+            assertThat(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri))
+                .contains("SUMMARY:" + initialSummary)
+                .contains("DESCRIPTION:" + initialDescription);
+            assertThat(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri))
+                .contains("SUMMARY:" + initialSummary)
+                .contains("DESCRIPTION:" + initialDescription);
+        });
+
+        // When Alice updates summary and description of her own event via HTTP PUT
+        String aliceUpdatedSummary = "Alice private summary";
+        String aliceUpdatedDescription = "Alice private note";
+        String aliceCalendarEventIcs = calDavClient.getCalendarEvent(alice, aliceCalendarEventUri);
+        String aliceUpdatedCalendarEventIcs = aliceCalendarEventIcs
+            .replace("SUMMARY:" + initialSummary, "SUMMARY:" + aliceUpdatedSummary)
+            .replace("DESCRIPTION:" + initialDescription, "DESCRIPTION:" + aliceUpdatedDescription);
+        calDavClient.upsertCalendarEvent(alice, aliceCalendarEventUri, aliceUpdatedCalendarEventIcs);
+
+        awaitAtMost.untilAsserted(() -> assertThat(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri))
+            .contains("SUMMARY:" + aliceUpdatedSummary)
+            .contains("DESCRIPTION:" + aliceUpdatedDescription));
+
+        // Then Bob and Cedric event does not change
+        URI bobCalendarEventUri = URI.create("/calendars/" + bob.id() + "/" + bob.id() + "/" + organizerEventUid + ".ics");
+        calmlyAwait
+            .during(3, TimeUnit.SECONDS)
+            .untilAsserted(() -> {
+                assertThat(calDavClient.getCalendarEvent(bob, bobCalendarEventUri))
+                    .contains("SUMMARY:" + initialSummary)
+                    .contains("DESCRIPTION:" + initialDescription)
+                    .doesNotContain("SUMMARY:" + aliceUpdatedSummary)
+                    .doesNotContain("DESCRIPTION:" + aliceUpdatedDescription);
+
+                assertThat(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri))
+                    .contains("SUMMARY:" + initialSummary)
+                    .contains("DESCRIPTION:" + initialDescription)
+                    .doesNotContain("SUMMARY:" + aliceUpdatedSummary)
+                    .doesNotContain("DESCRIPTION:" + aliceUpdatedDescription);
+            });
+    }
+
+    @Test
+    void attendeeUpdatingOrganizerParticipationShouldNotPropagateToOrganizerAndOtherAttendees() {
+        // Given Bob creates an event with Alice and Cedric as attendees
+        String organizerEventUid = "event-" + UUID.randomUUID();
+        String organizerEventIcs = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Example Corp.//CalDAV Client//EN
+            BEGIN:VEVENT
+            UID:{organizerEventUid}
+            DTSTAMP:20351003T080000Z
+            DTSTART:20351005T090000Z
+            DTEND:20351005T100000Z
+            SUMMARY:Participation isolation check
+            ORGANIZER:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=ACCEPTED;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:{aliceEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:{cedricEmail}
+            END:VEVENT
+            END:VCALENDAR
+            """
+            .replace("{organizerEventUid}", organizerEventUid)
+            .replace("{bobEmail}", bob.email())
+            .replace("{aliceEmail}", alice.email())
+            .replace("{cedricEmail}", cedric.email());
+        calDavClient.upsertCalendarEvent(bob, organizerEventUid, organizerEventIcs);
+
+        String aliceCalendarEventId = awaitFirstEventId(alice);
+        String cedricCalendarEventId = awaitFirstEventId(cedric);
+        URI aliceCalendarEventUri = URI.create("/calendars/" + alice.id() + "/" + alice.id() + "/" + aliceCalendarEventId + ".ics");
+        URI cedricCalendarEventUri = URI.create("/calendars/" + cedric.id() + "/" + cedric.id() + "/" + cedricCalendarEventId + ".ics");
+        URI bobCalendarEventUri = URI.create("/calendars/" + bob.id() + "/" + bob.id() + "/" + organizerEventUid + ".ics");
+
+        awaitAtMost.untilAsserted(() -> {
+            assertThat(CalendarUtil.getAttendeePartStat(calDavClient.getCalendarEvent(bob, bobCalendarEventUri), bob.email()))
+                .isEqualTo(PartStat.ACCEPTED);
+            assertThat(CalendarUtil.getAttendeePartStat(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri), bob.email()))
+                .isEqualTo(PartStat.ACCEPTED);
+        });
+
+        // When Alice changes Bob PARTSTAT in her own event copy
+        String aliceCalendarEventIcs = calDavClient.getCalendarEvent(alice, aliceCalendarEventUri);
+        String aliceUpdatedCalendarEventIcs = CalendarUtil.withAttendeePartStat(aliceCalendarEventIcs, bob.email(), PartStat.DECLINED);
+        calDavClient.upsertCalendarEvent(alice, aliceCalendarEventUri, aliceUpdatedCalendarEventIcs);
+
+        // Then Bob and Cedric calendars keep Bob participation untouched
+        calmlyAwait
+            .during(2, TimeUnit.SECONDS)
+            .untilAsserted(() -> {
+                assertThat(CalendarUtil.getAttendeePartStat(calDavClient.getCalendarEvent(bob, bobCalendarEventUri), bob.email()))
+                    .isEqualTo(PartStat.ACCEPTED);
+                assertThat(CalendarUtil.getAttendeePartStat(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri), bob.email()))
+                    .isEqualTo(PartStat.ACCEPTED);
+            });
+    }
+
+    @Test
+    void attendeeAddingNewAttendeeShouldNotPropagateToOthersNorInviteNewAttendee() {
+        // Given Bob creates an event with Alice and Cedric as attendees
+        String organizerEventUid = "event-" + UUID.randomUUID();
+        String organizerEventIcs = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Example Corp.//CalDAV Client//EN
+            BEGIN:VEVENT
+            UID:{organizerEventUid}
+            DTSTAMP:20351003T080000Z
+            DTSTART:20351005T090000Z
+            DTEND:20351005T100000Z
+            SUMMARY:Add attendee isolation check
+            ORGANIZER:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=ACCEPTED;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:{aliceEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:{cedricEmail}
+            END:VEVENT
+            END:VCALENDAR
+            """
+            .replace("{organizerEventUid}", organizerEventUid)
+            .replace("{bobEmail}", bob.email())
+            .replace("{aliceEmail}", alice.email())
+            .replace("{cedricEmail}", cedric.email());
+        calDavClient.upsertCalendarEvent(bob, organizerEventUid, organizerEventIcs);
+
+        String aliceCalendarEventId = awaitFirstEventId(alice);
+        String cedricCalendarEventId = awaitFirstEventId(cedric);
+        URI aliceCalendarEventUri = URI.create("/calendars/" + alice.id() + "/" + alice.id() + "/" + aliceCalendarEventId + ".ics");
+        URI cedricCalendarEventUri = URI.create("/calendars/" + cedric.id() + "/" + cedric.id() + "/" + cedricCalendarEventId + ".ics");
+        URI bobCalendarEventUri = URI.create("/calendars/" + bob.id() + "/" + bob.id() + "/" + organizerEventUid + ".ics");
+
+        // When Alice tries to add David in her copy
+        String davidAttendeeLine =
+            "ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:" + david.email();
+        String aliceCalendarEventIcs = calDavClient.getCalendarEvent(alice, aliceCalendarEventUri);
+        String aliceUpdatedCalendarEventIcs = aliceCalendarEventIcs.replace("END:VEVENT", davidAttendeeLine + "\nEND:VEVENT");
+        calDavClient.upsertCalendarEvent(alice, aliceCalendarEventUri, aliceUpdatedCalendarEventIcs);
+
+        // Then Bob and Cedric calendars are not updated with David, and David is not invited
+        calmlyAwait
+            .during(2, TimeUnit.SECONDS)
+            .untilAsserted(() -> {
+                assertThat(calDavClient.getCalendarEvent(bob, bobCalendarEventUri))
+                    .doesNotContain("mailto:" + david.email());
+                assertThat(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri))
+                    .doesNotContain("mailto:" + david.email());
+                assertThat(calDavClient.findFirstEventId(david))
+                    .isEmpty();
+            });
+    }
+
+    @Test
+    void attendeeChangingOrganizerShouldOnlyAffectAttendeeCalendar() {
+        // Given Bob creates an event with Alice and Cedric as attendees
+        String organizerEventUid = "event-" + UUID.randomUUID();
+        String organizerEventIcs = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Example Corp.//CalDAV Client//EN
+            BEGIN:VEVENT
+            UID:{organizerEventUid}
+            DTSTAMP:20351003T080000Z
+            DTSTART:20351005T090000Z
+            DTEND:20351005T100000Z
+            SUMMARY:Organizer isolation check
+            ORGANIZER:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=ACCEPTED;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:{aliceEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:{cedricEmail}
+            END:VEVENT
+            END:VCALENDAR
+            """
+            .replace("{organizerEventUid}", organizerEventUid)
+            .replace("{bobEmail}", bob.email())
+            .replace("{aliceEmail}", alice.email())
+            .replace("{cedricEmail}", cedric.email());
+        calDavClient.upsertCalendarEvent(bob, organizerEventUid, organizerEventIcs);
+
+        String aliceCalendarEventId = awaitFirstEventId(alice);
+        String cedricCalendarEventId = awaitFirstEventId(cedric);
+        URI aliceCalendarEventUri = URI.create("/calendars/" + alice.id() + "/" + alice.id() + "/" + aliceCalendarEventId + ".ics");
+        URI cedricCalendarEventUri = URI.create("/calendars/" + cedric.id() + "/" + cedric.id() + "/" + cedricCalendarEventId + ".ics");
+        URI bobCalendarEventUri = URI.create("/calendars/" + bob.id() + "/" + bob.id() + "/" + organizerEventUid + ".ics");
+
+        // When Alice changes ORGANIZER in her own event
+        String aliceCalendarEventIcs = calDavClient.getCalendarEvent(alice, aliceCalendarEventUri);
+        String aliceUpdatedCalendarEventIcs = aliceCalendarEventIcs
+            .replace("ORGANIZER:mailto:" + bob.email(), "ORGANIZER:mailto:" + alice.email());
+        calDavClient.upsertCalendarEvent(alice, aliceCalendarEventUri, aliceUpdatedCalendarEventIcs);
+
+        awaitAtMost.untilAsserted(() -> assertThat(CalendarUtil.getOrganizer(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri)))
+            .isEqualTo("mailto:" + alice.email()));
+
+        // Then Bob and Cedric calendars still point to Bob as organizer
+        calmlyAwait
+            .during(2, TimeUnit.SECONDS)
+            .untilAsserted(() -> {
+                assertThat(CalendarUtil.getOrganizer(calDavClient.getCalendarEvent(bob, bobCalendarEventUri)))
+                    .isEqualTo("mailto:" + bob.email());
+                assertThat(CalendarUtil.getOrganizer(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri)))
+                    .isEqualTo("mailto:" + bob.email());
+            });
     }
 
     @Test

--- a/src/test/java/com/linagora/dav/contracts/cal/SchedulingContract.java
+++ b/src/test/java/com/linagora/dav/contracts/cal/SchedulingContract.java
@@ -29,10 +29,13 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.shaded.org.awaitility.Awaitility;
 import org.testcontainers.shaded.org.awaitility.core.ConditionFactory;
 
@@ -342,7 +345,7 @@ public abstract class SchedulingContract {
     }
 
     @Test
-    void attendeeUpdatingVALARMShouldOnlyAffectAttendeeCalendar() {
+    void attendeeUpdatingVALARMShouldNotPropagateToOrganizerAndOtherAttendees() {
         // Given Bob creates an event with Alice and Cedric as attendees and a VALARM
         String organizerEventUid = "event-" + UUID.randomUUID();
         String organizerEventIcs = """
@@ -581,7 +584,7 @@ public abstract class SchedulingContract {
     }
 
     @Test
-    void attendeeUpdatingTRANSPShouldOnlyAffectAttendeeCalendar() {
+    void attendeeUpdatingTRANSPShouldNotPropagateToOrganizerAndOtherAttendees() {
         // Given Bob creates an event with Alice and Cedric as attendees and TRANSP set to OPAQUE
         String organizerEventUid = "event-" + UUID.randomUUID();
         String organizerEventIcs = """
@@ -795,12 +798,36 @@ public abstract class SchedulingContract {
             .isEqualTo(TRANSP_TRANSPARENT);
     }
 
-    @Test
-    void attendeePUTUpdateShouldNotPropagateToOrganizerAndOtherAttendees() {
+    record PropertyChange(String propertyName, String originalValue, String updatedValue) {
+        @Override
+        public String toString() {
+            return propertyName;
+        }
+
+        String originalLine() {
+            return propertyName + ":" + originalValue;
+        }
+
+        String updatedLine() {
+            return propertyName + ":" + updatedValue;
+        }
+    }
+
+    static Stream<PropertyChange> coreEventPropertyUpdates() {
+        return Stream.of(
+            new PropertyChange(Property.SUMMARY, "Shared title", "Alice local title"),
+            new PropertyChange(Property.DESCRIPTION, "Shared description", "Alice local description"),
+            new PropertyChange(Property.DTSTART, "20351005T090000Z", "20351005T093000Z"),
+            new PropertyChange(Property.DTEND, "20351005T100000Z", "20351005T120000Z"),
+            new PropertyChange(Property.CLASS, "PUBLIC", "PRIVATE"),
+            new PropertyChange(Property.LOCATION, "Room A", "Room B"));
+    }
+
+    @ParameterizedTest(name = "[{index}] attendee updating {0} should not propagate to organizer and other attendees")
+    @MethodSource("coreEventPropertyUpdates")
+    void attendeePUTUpdateShouldNotPropagateToOrganizerAndOtherAttendees(PropertyChange change) {
         // Given Bob creates an event with Alice and Cedric as attendees
         String organizerEventUid = "event-" + UUID.randomUUID();
-        String initialSummary = "Planning meeting";
-        String initialDescription = "Initial note from Bob";
         String organizerEventIcs = """
             BEGIN:VCALENDAR
             VERSION:2.0
@@ -810,8 +837,11 @@ public abstract class SchedulingContract {
             DTSTAMP:20351003T080000Z
             DTSTART:20351005T090000Z
             DTEND:20351005T100000Z
-            SUMMARY:{summary}
-            DESCRIPTION:{description}
+            SUMMARY:Shared title
+            DESCRIPTION:Shared description
+            CLASS:PUBLIC
+            LOCATION:Room A
+            STATUS:CONFIRMED
             ORGANIZER:mailto:{bobEmail}
             ATTENDEE;PARTSTAT=ACCEPTED;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:{bobEmail}
             ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:{aliceEmail}
@@ -820,8 +850,6 @@ public abstract class SchedulingContract {
             END:VCALENDAR
             """
             .replace("{organizerEventUid}", organizerEventUid)
-            .replace("{summary}", initialSummary)
-            .replace("{description}", initialDescription)
             .replace("{bobEmail}", bob.email())
             .replace("{aliceEmail}", alice.email())
             .replace("{cedricEmail}", cedric.email());
@@ -829,49 +857,38 @@ public abstract class SchedulingContract {
 
         String aliceCalendarEventId = awaitFirstEventId(alice);
         String cedricCalendarEventId = awaitFirstEventId(cedric);
-
-        // And both attendees can already see the invited event
         URI aliceCalendarEventUri = URI.create("/calendars/" + alice.id() + "/" + alice.id() + "/" + aliceCalendarEventId + ".ics");
         URI cedricCalendarEventUri = URI.create("/calendars/" + cedric.id() + "/" + cedric.id() + "/" + cedricCalendarEventId + ".ics");
+        URI bobCalendarEventUri = URI.create("/calendars/" + bob.id() + "/" + bob.id() + "/" + organizerEventUid + ".ics");
+        String changedPropertyName = change.propertyName();
+        String originalPropertyValue = change.originalValue();
+        String updatedPropertyValue = change.updatedValue();
 
-        awaitAtMost.untilAsserted(() -> {
-            assertThat(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri))
-                .contains("SUMMARY:" + initialSummary)
-                .contains("DESCRIPTION:" + initialDescription);
-            assertThat(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri))
-                .contains("SUMMARY:" + initialSummary)
-                .contains("DESCRIPTION:" + initialDescription);
-        });
+        awaitAtMost.untilAsserted(() -> assertThat(CalendarUtil.toExtractor(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri))
+            .extractPropertyValue(changedPropertyName))
+            .isEqualTo(originalPropertyValue));
 
-        // When Alice updates summary and description of her own event via HTTP PUT
-        String aliceUpdatedSummary = "Alice private summary";
-        String aliceUpdatedDescription = "Alice private note";
+        // When Alice updates property in her copy
         String aliceCalendarEventIcs = calDavClient.getCalendarEvent(alice, aliceCalendarEventUri);
         String aliceUpdatedCalendarEventIcs = aliceCalendarEventIcs
-            .replace("SUMMARY:" + initialSummary, "SUMMARY:" + aliceUpdatedSummary)
-            .replace("DESCRIPTION:" + initialDescription, "DESCRIPTION:" + aliceUpdatedDescription);
+            .replace(change.originalLine(), change.updatedLine());
         calDavClient.upsertCalendarEvent(alice, aliceCalendarEventUri, aliceUpdatedCalendarEventIcs);
 
-        awaitAtMost.untilAsserted(() -> assertThat(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri))
-            .contains("SUMMARY:" + aliceUpdatedSummary)
-            .contains("DESCRIPTION:" + aliceUpdatedDescription));
+        awaitAtMost.untilAsserted(() -> assertThat(CalendarUtil.toExtractor(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri))
+            .extractPropertyValue(changedPropertyName))
+            .isEqualTo(updatedPropertyValue));
 
-        // Then Bob and Cedric event does not change
-        URI bobCalendarEventUri = URI.create("/calendars/" + bob.id() + "/" + bob.id() + "/" + organizerEventUid + ".ics");
+        // Then Bob and Cedric calendars keep organizer values unchanged
         calmlyAwait
-            .during(3, TimeUnit.SECONDS)
+            .during(2, TimeUnit.SECONDS)
             .untilAsserted(() -> {
-                assertThat(calDavClient.getCalendarEvent(bob, bobCalendarEventUri))
-                    .contains("SUMMARY:" + initialSummary)
-                    .contains("DESCRIPTION:" + initialDescription)
-                    .doesNotContain("SUMMARY:" + aliceUpdatedSummary)
-                    .doesNotContain("DESCRIPTION:" + aliceUpdatedDescription);
+                assertThat(CalendarUtil.toExtractor(calDavClient.getCalendarEvent(bob, bobCalendarEventUri))
+                    .extractPropertyValue(changedPropertyName))
+                    .isEqualTo(originalPropertyValue);
 
-                assertThat(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri))
-                    .contains("SUMMARY:" + initialSummary)
-                    .contains("DESCRIPTION:" + initialDescription)
-                    .doesNotContain("SUMMARY:" + aliceUpdatedSummary)
-                    .doesNotContain("DESCRIPTION:" + aliceUpdatedDescription);
+                assertThat(CalendarUtil.toExtractor(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri))
+                    .extractPropertyValue(changedPropertyName))
+                    .isEqualTo(originalPropertyValue);
             });
     }
 
@@ -1023,16 +1040,19 @@ public abstract class SchedulingContract {
             .replace("ORGANIZER:mailto:" + bob.email(), "ORGANIZER:mailto:" + alice.email());
         calDavClient.upsertCalendarEvent(alice, aliceCalendarEventUri, aliceUpdatedCalendarEventIcs);
 
-        awaitAtMost.untilAsserted(() -> assertThat(CalendarUtil.getOrganizer(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri)))
+        awaitAtMost.untilAsserted(() -> assertThat(CalendarUtil.toExtractor(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri))
+            .extractPropertyValue(Property.ORGANIZER))
             .isEqualTo("mailto:" + alice.email()));
 
         // Then Bob and Cedric calendars still point to Bob as organizer
         calmlyAwait
             .during(2, TimeUnit.SECONDS)
             .untilAsserted(() -> {
-                assertThat(CalendarUtil.getOrganizer(calDavClient.getCalendarEvent(bob, bobCalendarEventUri)))
+                assertThat(CalendarUtil.toExtractor(calDavClient.getCalendarEvent(bob, bobCalendarEventUri))
+                    .extractPropertyValue(Property.ORGANIZER))
                     .isEqualTo("mailto:" + bob.email());
-                assertThat(CalendarUtil.getOrganizer(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri)))
+                assertThat(CalendarUtil.toExtractor(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri))
+                    .extractPropertyValue(Property.ORGANIZER))
                     .isEqualTo("mailto:" + bob.email());
             });
     }

--- a/src/test/java/com/linagora/dav/contracts/cal/SchedulingContract.java
+++ b/src/test/java/com/linagora/dav/contracts/cal/SchedulingContract.java
@@ -1084,6 +1084,7 @@ public abstract class SchedulingContract {
             });
     }
 
+    @Disabled("esn-sabre issue https://github.com/linagora/esn-sabre/issues/321")
     @Test
     void attendeeChangingOrganizerShouldOnlyAffectAttendeeCalendar() {
         // Given Bob creates an event with Alice and Cedric as attendees


### PR DESCRIPTION
This protects scheduling consistency by ensuring attendee-side content edits stay local and do not overwrite organizer/peer attendee copies.

ref: https://www.rfc-editor.org/rfc/rfc5546