### PR TITLE
test(scheduling): add VALARM isolation coverage for attendee local alarms

### DIFF
--- a/src/test/java/com/linagora/dav/contracts/cal/SchedulingContract.java
+++ b/src/test/java/com/linagora/dav/contracts/cal/SchedulingContract.java
@@ -42,10 +42,14 @@ import com.linagora.dav.DockerTwakeCalendarExtension;
 import com.linagora.dav.OpenPaasUser;
 
 import net.fortuna.ical4j.model.Calendar;
+import net.fortuna.ical4j.model.Component;
 import net.fortuna.ical4j.model.Property;
 import net.fortuna.ical4j.model.parameter.PartStat;
 
 public abstract class SchedulingContract {
+    private static final String ALARM_TRIGGER_15M = "-PT15M";
+    private static final String ALARM_TRIGGER_5M = "-PT5M";
+
     private static final String[] IGNORED_CALENDAR_PROPERTIES = {
         Property.SEQUENCE,
         Property.CALSCALE,
@@ -330,6 +334,243 @@ public abstract class SchedulingContract {
         // Then Alice calendar reflects Cedric acceptance
         awaitAtMost.untilAsserted(() -> assertThat(cedricPartStatOnAliceCalendar.get())
             .isEqualTo(PartStat.ACCEPTED));
+    }
+
+    @Test
+    void attendeeUpdatingVALARMShouldOnlyAffectAttendeeCalendar() {
+        // Given Bob creates an event with Alice and Cedric as attendees and a VALARM
+        String organizerEventUid = "event-" + UUID.randomUUID();
+        String organizerEventIcs = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Sabre//Sabre VObject 4.1.3//EN
+            CALSCALE:GREGORIAN
+            BEGIN:VEVENT
+            UID:{organizerEventUid}
+            SEQUENCE:1
+            DTSTART:30250101T090000Z
+            DTEND:30250101T100000Z
+            SUMMARY:Alarm sync isolation check
+            LOCATION:Meeting Room A
+            DESCRIPTION:Check attendee local alarm update isolation
+            ORGANIZER;CN=Bob:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;CN=Alice:mailto:{aliceEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;CN=Cedric:mailto:{cedricEmail}
+            ATTENDEE;PARTSTAT=ACCEPTED;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:{bobEmail}
+            BEGIN:VALARM
+            TRIGGER:{alarmTrigger15m}
+            ACTION:EMAIL
+            ATTENDEE:mailto:{bobEmail}
+            SUMMARY:test alarm
+            DESCRIPTION:This is an automatic alarm sent by OpenPaas
+            END:VALARM
+            END:VEVENT
+            END:VCALENDAR
+            """
+            .replace("{organizerEventUid}", organizerEventUid)
+            .replace("{bobEmail}", bob.email())
+            .replace("{aliceEmail}", alice.email())
+            .replace("{cedricEmail}", cedric.email())
+            .replace("{alarmTrigger15m}", ALARM_TRIGGER_15M);
+        calDavClient.upsertCalendarEvent(bob, organizerEventUid, organizerEventIcs);
+
+        String aliceCalendarEventId = awaitFirstEventId(alice);
+        String cedricCalendarEventId = awaitFirstEventId(cedric);
+        URI aliceCalendarEventUri = URI.create("/calendars/" + alice.id() + "/" + alice.id() + "/" + aliceCalendarEventId + ".ics");
+        URI cedricCalendarEventUri = URI.create("/calendars/" + cedric.id() + "/" + cedric.id() + "/" + cedricCalendarEventId + ".ics");
+        URI bobCalendarEventUri = URI.create("/calendars/" + bob.id() + "/" + bob.id() + "/" + organizerEventUid + ".ics");
+
+        awaitAtMost.untilAsserted(() -> {
+            assertThat(readFirstAlarmTrigger(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri)))
+                .isEqualTo(ALARM_TRIGGER_15M);
+            assertThat(readFirstAlarmTrigger(calDavClient.getCalendarEvent(bob, bobCalendarEventUri)))
+                .isEqualTo(ALARM_TRIGGER_15M);
+            assertThat(readFirstAlarmTrigger(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri)))
+                .isEqualTo(ALARM_TRIGGER_15M);
+        });
+
+        // When Alice updates VALARM trigger in her own event copy via HTTP PUT
+        String aliceCalendarEventIcs = calDavClient.getCalendarEvent(alice, aliceCalendarEventUri);
+        String aliceUpdatedCalendarEventIcs = aliceCalendarEventIcs
+            .replace("TRIGGER:" + ALARM_TRIGGER_15M, "TRIGGER:" + ALARM_TRIGGER_5M);
+        calDavClient.upsertCalendarEvent(alice, aliceCalendarEventUri, aliceUpdatedCalendarEventIcs);
+
+        // Then Alice calendar reflects updated alarm
+        awaitAtMost.untilAsserted(() -> assertThat(readFirstAlarmTrigger(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri)))
+            .isEqualTo(ALARM_TRIGGER_5M));
+
+        // And Bob and Cedric calendars keep original alarm trigger
+        calmlyAwait
+            .during(2, TimeUnit.SECONDS)
+            .untilAsserted(() -> {
+                assertThat(readFirstAlarmTrigger(calDavClient.getCalendarEvent(bob, bobCalendarEventUri)))
+                    .isEqualTo(ALARM_TRIGGER_15M);
+                assertThat(readFirstAlarmTrigger(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri)))
+                    .isEqualTo(ALARM_TRIGGER_15M);
+            });
+    }
+
+    @Test
+    void organizerUpdateShouldNotResetAttendeeLocalVALARM() {
+        // Given Bob creates an event with Alice and Cedric as attendees and a VALARM
+        String organizerEventUid = "event-" + UUID.randomUUID();
+        String initialSummary = "Alarm reset check";
+        String updatedSummary = "Alarm reset check - updated by Bob";
+        String organizerEventIcs = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Sabre//Sabre VObject 4.1.3//EN
+            CALSCALE:GREGORIAN
+            BEGIN:VEVENT
+            UID:{organizerEventUid}
+            SEQUENCE:1
+            DTSTART:30250101T090000Z
+            DTEND:30250101T100000Z
+            SUMMARY:{summary}
+            LOCATION:Meeting Room A
+            DESCRIPTION:Check attendee alarm persistence after organizer update
+            ORGANIZER;CN=Bob:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;CN=Alice:mailto:{aliceEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;CN=Cedric:mailto:{cedricEmail}
+            ATTENDEE;PARTSTAT=ACCEPTED;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:{bobEmail}
+            BEGIN:VALARM
+            TRIGGER:{alarmTrigger15m}
+            ACTION:EMAIL
+            ATTENDEE:mailto:{bobEmail}
+            SUMMARY:test alarm
+            DESCRIPTION:This is an automatic alarm sent by OpenPaas
+            END:VALARM
+            END:VEVENT
+            END:VCALENDAR
+            """
+            .replace("{organizerEventUid}", organizerEventUid)
+            .replace("{summary}", initialSummary)
+            .replace("{bobEmail}", bob.email())
+            .replace("{aliceEmail}", alice.email())
+            .replace("{cedricEmail}", cedric.email())
+            .replace("{alarmTrigger15m}", ALARM_TRIGGER_15M);
+        calDavClient.upsertCalendarEvent(bob, organizerEventUid, organizerEventIcs);
+
+        String aliceCalendarEventId = awaitFirstEventId(alice);
+        String cedricCalendarEventId = awaitFirstEventId(cedric);
+        URI aliceCalendarEventUri = URI.create("/calendars/" + alice.id() + "/" + alice.id() + "/" + aliceCalendarEventId + ".ics");
+        URI cedricCalendarEventUri = URI.create("/calendars/" + cedric.id() + "/" + cedric.id() + "/" + cedricCalendarEventId + ".ics");
+        URI bobCalendarEventUri = URI.create("/calendars/" + bob.id() + "/" + bob.id() + "/" + organizerEventUid + ".ics");
+
+        awaitAtMost.untilAsserted(() -> {
+            assertThat(readFirstAlarmTrigger(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri)))
+                .isEqualTo(ALARM_TRIGGER_15M);
+            assertThat(readEventSummary(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri)))
+                .isEqualTo(initialSummary);
+        });
+
+        // When Alice updates VALARM trigger in her own event copy
+        String aliceCalendarEventIcs = calDavClient.getCalendarEvent(alice, aliceCalendarEventUri);
+        String aliceUpdatedCalendarEventIcs = aliceCalendarEventIcs
+            .replace("TRIGGER:" + ALARM_TRIGGER_15M, "TRIGGER:" + ALARM_TRIGGER_5M);
+        calDavClient.upsertCalendarEvent(alice, aliceCalendarEventUri, aliceUpdatedCalendarEventIcs);
+
+        awaitAtMost.untilAsserted(() -> assertThat(readFirstAlarmTrigger(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri)))
+            .isEqualTo(ALARM_TRIGGER_5M));
+
+        // And Bob updates event summary
+        String bobCalendarEventIcs = calDavClient.getCalendarEvent(bob, bobCalendarEventUri);
+        String bobUpdatedCalendarEventIcs = bobCalendarEventIcs
+            .replace("SUMMARY:" + initialSummary, "SUMMARY:" + updatedSummary);
+        calDavClient.upsertCalendarEvent(bob, bobCalendarEventUri, bobUpdatedCalendarEventIcs);
+
+        // Then summary is synchronized, but Alice local alarm is not reset by Bob update
+        awaitAtMost.untilAsserted(() -> {
+            assertThat(readEventSummary(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri)))
+                .isEqualTo(updatedSummary);
+            assertThat(readEventSummary(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri)))
+                .isEqualTo(updatedSummary);
+        });
+
+        calmlyAwait
+            .during(2, TimeUnit.SECONDS)
+            .untilAsserted(() -> {
+                assertThat(readFirstAlarmTrigger(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri)))
+                    .isEqualTo(ALARM_TRIGGER_5M);
+                assertThat(readFirstAlarmTrigger(calDavClient.getCalendarEvent(bob, bobCalendarEventUri)))
+                    .isEqualTo(ALARM_TRIGGER_15M);
+                assertThat(readFirstAlarmTrigger(calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri)))
+                    .isEqualTo(ALARM_TRIGGER_15M);
+            });
+    }
+
+    @Test
+    void attendeePartStatUpdateShouldNotResetOtherAttendeeLocalVALARM() {
+        // Given Bob creates an event with Alice and Cedric as attendees and a VALARM
+        String organizerEventUid = "event-" + UUID.randomUUID();
+        String organizerEventIcs = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Sabre//Sabre VObject 4.1.3//EN
+            CALSCALE:GREGORIAN
+            BEGIN:VEVENT
+            UID:{organizerEventUid}
+            SEQUENCE:1
+            DTSTART:30250101T090000Z
+            DTEND:30250101T100000Z
+            SUMMARY:PartStat and alarm isolation
+            LOCATION:Meeting Room A
+            DESCRIPTION:Check alarm is preserved when attendee updates partstat
+            ORGANIZER;CN=Bob:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;CN=Alice:mailto:{aliceEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;CN=Cedric:mailto:{cedricEmail}
+            ATTENDEE;PARTSTAT=ACCEPTED;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:{bobEmail}
+            BEGIN:VALARM
+            TRIGGER:{alarmTrigger15m}
+            ACTION:EMAIL
+            ATTENDEE:mailto:{bobEmail}
+            SUMMARY:test alarm
+            DESCRIPTION:This is an automatic alarm sent by OpenPaas
+            END:VALARM
+            END:VEVENT
+            END:VCALENDAR
+            """
+            .replace("{organizerEventUid}", organizerEventUid)
+            .replace("{bobEmail}", bob.email())
+            .replace("{aliceEmail}", alice.email())
+            .replace("{cedricEmail}", cedric.email())
+            .replace("{alarmTrigger15m}", ALARM_TRIGGER_15M);
+        calDavClient.upsertCalendarEvent(bob, organizerEventUid, organizerEventIcs);
+
+        String aliceCalendarEventId = awaitFirstEventId(alice);
+        String cedricCalendarEventId = awaitFirstEventId(cedric);
+        URI aliceCalendarEventUri = URI.create("/calendars/" + alice.id() + "/" + alice.id() + "/" + aliceCalendarEventId + ".ics");
+        URI cedricCalendarEventUri = URI.create("/calendars/" + cedric.id() + "/" + cedric.id() + "/" + cedricCalendarEventId + ".ics");
+
+        awaitAtMost.untilAsserted(() -> {
+            assertThat(readFirstAlarmTrigger(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri)))
+                .isEqualTo(ALARM_TRIGGER_15M);
+            assertThat(CalendarUtil.getAttendeePartStat(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri), cedric.email()))
+                .isEqualTo(PartStat.NEEDS_ACTION);
+        });
+
+        // And Alice customizes her local VALARM
+        String aliceCalendarEventIcs = calDavClient.getCalendarEvent(alice, aliceCalendarEventUri);
+        String aliceUpdatedCalendarEventIcs = aliceCalendarEventIcs
+            .replace("TRIGGER:" + ALARM_TRIGGER_15M, "TRIGGER:" + ALARM_TRIGGER_5M);
+        calDavClient.upsertCalendarEvent(alice, aliceCalendarEventUri, aliceUpdatedCalendarEventIcs);
+
+        awaitAtMost.untilAsserted(() -> assertThat(readFirstAlarmTrigger(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri)))
+            .isEqualTo(ALARM_TRIGGER_5M));
+
+        // When Cedric accepts the event (updates his own PARTSTAT)
+        String cedricCalendarEventIcs = calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri);
+        String cedricAcceptedCalendarEventIcs = CalendarUtil.withAttendeePartStat(cedricCalendarEventIcs, cedric.email(), PartStat.ACCEPTED);
+        calDavClient.upsertCalendarEvent(cedric, cedricCalendarEventUri, cedricAcceptedCalendarEventIcs);
+
+        // Then Cedric PARTSTAT is synchronized to Alice
+        awaitAtMost.untilAsserted(() -> assertThat(CalendarUtil.getAttendeePartStat(
+            calDavClient.getCalendarEvent(alice, aliceCalendarEventUri), cedric.email()))
+            .isEqualTo(PartStat.ACCEPTED));
+
+        // And Alice local VALARM is not reset by that attendee update
+        assertThat(readFirstAlarmTrigger(calDavClient.getCalendarEvent(alice, aliceCalendarEventUri)))
+            .isEqualTo(ALARM_TRIGGER_5M);
     }
 
     @Test
@@ -1787,5 +2028,22 @@ public abstract class SchedulingContract {
         return awaitAtMost.until(() -> calDavClient.findFirstEventId(user),
             Optional::isPresent)
             .orElseThrow(() -> new AssertionError("Expected event id to be present"));
+    }
+
+    private String readFirstAlarmTrigger(String icsContent) {
+        return icsContent.lines()
+            .map(String::trim)
+            .filter(line -> line.startsWith("TRIGGER:"))
+            .map(line -> line.substring("TRIGGER:".length()))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Expected VALARM trigger to be present"));
+    }
+
+    private String readEventSummary(String icsContent) {
+        Calendar calendar = CalendarUtil.parseIcsAndSanitize(icsContent);
+        return calendar.getComponent(Component.VEVENT)
+            .flatMap(vevent -> vevent.getProperty(Property.SUMMARY))
+            .map(summary -> ((Property) summary).getValue())
+            .orElseThrow(() -> new AssertionError("Expected VEVENT summary to be present"));
     }
 }

--- a/src/test/java/com/linagora/dav/contracts/cal/SchedulingContract.java
+++ b/src/test/java/com/linagora/dav/contracts/cal/SchedulingContract.java
@@ -410,6 +410,7 @@ public abstract class SchedulingContract {
             });
     }
 
+    @Disabled("esn-sabre issue https://github.com/linagora/esn-sabre/issues/319")
     @Test
     void organizerUpdateShouldNotResetAttendeeLocalVALARM() {
         // Given Bob creates an event with Alice and Cedric as attendees and a VALARM
@@ -499,6 +500,7 @@ public abstract class SchedulingContract {
             });
     }
 
+    @Disabled("esn-sabre issue https://github.com/linagora/esn-sabre/issues/319")
     @Test
     void attendeePartStatUpdateShouldNotResetOtherAttendeeLocalVALARM() {
         // Given Bob creates an event with Alice and Cedric as attendees and a VALARM


### PR DESCRIPTION
- Attendee VALARM update must not propagate to organizer or other attendees
- Organizer event update (e.g. summary change) must not reset attendee local alarm
- Another attendee's PARTSTAT update must not reset a different attendee's local alarm