### PR TITLE
test(scheduling): re-enable attendee override scheduling contract

### DIFF
--- a/src/test/java/com/linagora/dav/contracts/cal/SchedulingContract.java
+++ b/src/test/java/com/linagora/dav/contracts/cal/SchedulingContract.java
@@ -19,8 +19,8 @@
 package com.linagora.dav.contracts.cal;
 
 import static com.linagora.dav.CalendarAssert.assertThatCalendar;
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import java.net.URI;
 import java.time.Duration;
@@ -1064,7 +1064,6 @@ public abstract class SchedulingContract {
             });
     }
 
-    @Disabled("esn-sabre issue https://github.com/linagora/esn-sabre/issues/322")
     @Test
     void attendeeCreatingNewOverrideShouldNotPropagateToOrganizerAndOtherAttendees() {
         // Given Bob creates a recurring master event (no override) and invites Alice and Cedric

--- a/src/test/java/com/linagora/dav/contracts/cal/SchedulingContract.java
+++ b/src/test/java/com/linagora/dav/contracts/cal/SchedulingContract.java
@@ -31,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -1066,6 +1067,9 @@ public abstract class SchedulingContract {
 
     @Test
     void attendeeCreatingNewOverrideShouldNotPropagateToOrganizerAndOtherAttendees() {
+        Assumptions.assumeTrue(Boolean.parseBoolean(System.getProperty("amqp.scheduling.enabled")),
+            "Fixed with async scheduling");
+
         // Given Bob creates a recurring master event (no override) and invites Alice and Cedric
         String organizerEventUid = "event-" + UUID.randomUUID();
         String overrideRecurrenceIdLine = "RECURRENCE-ID:20351006T090000Z";


### PR DESCRIPTION
Waiting for upstream PR to be merged.
-  https://github.com/linagora/twake-calendar-side-service/pull/708