### PR TITLE
esn-sabre/issues/347 - test(calendar-sharing): cover safe delete from read-only mirrors

### DIFF
--- a/src/test/java/com/linagora/dav/CalDavClient.java
+++ b/src/test/java/com/linagora/dav/CalDavClient.java
@@ -617,10 +617,10 @@ public class CalDavClient {
         return new CalendarURL(userId, calendarId);
     }
 
-    public void subscribeToSharedCalendar(OpenPaasUser user, SubscribedCalendarRequest subscribedCalendarRequest) {
+    public CalendarURL subscribeToSharedCalendar(OpenPaasUser user, SubscribedCalendarRequest subscribedCalendarRequest) {
         String uri = CalendarURL.CALENDAR_URL_PATH_PREFIX + "/" + user.id() + ".json";
 
-        httpClient.headers(headers -> user.impersonatedBasicAuth(headers)
+        return httpClient.headers(headers -> user.impersonatedBasicAuth(headers)
                 .add(HttpHeaderNames.CONTENT_TYPE, "application/json;charset=UTF-8")
                 .add(HttpHeaderNames.ACCEPT, "application/json, text/plain, */*"))
             .request(HttpMethod.POST)
@@ -628,7 +628,7 @@ public class CalDavClient {
             .send(Mono.just(Unpooled.wrappedBuffer(subscribedCalendarRequest.serialize().getBytes(StandardCharsets.UTF_8))))
             .responseSingle((response, responseContent) -> {
                 if (response.status().code() == 201) {
-                    return Mono.empty();
+                    return Mono.just(new CalendarURL(user.id(), subscribedCalendarRequest.id()));
                 }
                 return responseContent.asString(StandardCharsets.UTF_8)
                     .switchIfEmpty(Mono.just(StringUtils.EMPTY))

--- a/src/test/java/com/linagora/dav/contracts/cal/CalDavDelegationContract.java
+++ b/src/test/java/com/linagora/dav/contracts/cal/CalDavDelegationContract.java
@@ -29,6 +29,7 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -82,6 +83,7 @@ import net.fortuna.ical4j.model.Calendar;
 import net.fortuna.ical4j.model.Component;
 import net.fortuna.ical4j.model.Property;
 import net.fortuna.ical4j.model.component.VEvent;
+import net.fortuna.ical4j.model.parameter.PartStat;
 import reactor.core.publisher.Mono;
 import reactor.util.retry.Retry;
 
@@ -1704,6 +1706,150 @@ public abstract class CalDavDelegationContract {
         // THEN a 403 error is thrown
         assertThatThrownBy(() -> calDavClient.deleteCalendarEvent(alice, calendarURL, eventUid))
             .hasMessageContaining("Unexpected status code: 403 when delete calendar object");
+    }
+
+    @Test
+    void deleteFromReadDelegatedCalendarShouldNotDeleteOriginCalendar() {
+        OpenPaasUser bob = dockerExtension().newTestUser();
+        OpenPaasUser alice = dockerExtension().newTestUser();
+
+        // GIVEN Bob has a calendar with an event
+        String eventUid = UUID.randomUUID().toString();
+        String calendarData = TwakeCalendarEvent.builder()
+            .uid(eventUid)
+            .organizer(bob.email())
+            .summary("Bob's protected delegated event")
+            .location("Twake Meeting Room")
+            .description("This event must remain in Bob's origin calendar.")
+            .dtstart("20300411T100000")
+            .dtend("20300411T110000")
+            .build()
+            .toString();
+        calDavClient.upsertCalendarEvent(bob, eventUid, calendarData);
+
+        // AND Bob delegates that calendar to Alice with READ only
+        calDavClient.grantDelegation(bob, bob.id(), alice, DelegationRight.READ);
+
+        CalendarURL mirrorCalendarURL = calDavClient.findUserCalendars(alice)
+            .filter(url -> !url.base().equals(url.calendarId()))
+            .next().block();
+        URI mirrorEventUri = URI.create(mirrorCalendarURL.asUri() + "/" + eventUid + ".ics");
+
+        // WHEN Alice deletes the event via the delegated mirror calendar
+        int mirrorDeleteStatus = executeNoContent(dockerExtension().davHttpClient()
+            .headers(headers -> alice.impersonatedBasicAuth(headers)
+                .add("Content-Type", "text/calendar ; charset=utf-8"))
+            .delete()
+            .uri(mirrorEventUri.toASCIIString()));
+
+        // AND Bob's origin calendar object must remain regardless of the mirror DELETE status
+        URI originEventUri = URI.create("/calendars/" + bob.id() + "/" + bob.id() + "/" + eventUid + ".ics");
+        DavResponse originEventResponse = execute(dockerExtension().davHttpClient()
+            .headers(headers -> bob.impersonatedBasicAuth(headers)
+                .add("Content-Type", "text/calendar ; charset=utf-8"))
+            .get()
+            .uri(originEventUri.toASCIIString()));
+
+        assertSoftly(softly -> {
+            softly.assertThat(mirrorDeleteStatus)
+                .as("Read-only delegated mirror DELETE should be rejected")
+                .isEqualTo(403);
+            softly.assertThat(originEventResponse.status())
+                .as("Origin calendar event must remain when mirror DELETE returned " + mirrorDeleteStatus)
+                .isEqualTo(200);
+            softly.assertThat(originEventResponse.body())
+                .contains(eventUid)
+                .contains("SUMMARY:Bob's protected delegated event");
+        });
+    }
+
+    @Test
+    void partStatUpdateFromReadDelegatedAttendeeCalendarShouldNotPropagateToOrganizerCalendar() {
+        OpenPaasUser bob = dockerExtension().newTestUser();
+        OpenPaasUser alice = dockerExtension().newTestUser();
+        OpenPaasUser david = dockerExtension().newTestUser();
+
+        // GIVEN Bob is the organizer of an event with Alice as attendee
+        String eventUid = "event-" + UUID.randomUUID();
+        String calendarData = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Example Corp.//CalDAV Client//EN
+            BEGIN:VEVENT
+            UID:%s
+            DTSTAMP:20300411T080000Z
+            DTSTART:20300411T100000Z
+            DTEND:20300411T110000Z
+            SUMMARY:Bob delegated attendee event
+            ORGANIZER;CN=Bob:mailto:%s
+            ATTENDEE;PARTSTAT=ACCEPTED;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:%s
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL;CN=Alice:mailto:%s
+            END:VEVENT
+            END:VCALENDAR
+            """.formatted(eventUid, bob.email(), bob.email(), alice.email());
+
+        calDavClient.upsertCalendarEvent(bob, eventUid, calendarData);
+
+        URI organizerEventUri = URI.create("/calendars/" + bob.id() + "/" + bob.id() + "/" + eventUid + ".ics");
+        CalendarURL aliceDefaultCalendarURL = CalendarURL.from(alice.id());
+
+        // AND Alice receives the invited event in her own calendar
+        URI aliceEventUri = awaitAtMost.until(
+                () -> calDavClient.findFirstUserCalendarObjectUriByEventUid(alice, aliceDefaultCalendarURL, eventUid),
+                Optional::isPresent)
+            .orElseThrow(() -> new AssertionError("Expected invited event to be present in Alice calendar"));
+        awaitAtMost.untilAsserted(() -> assertSoftly(softly -> {
+            softly.assertThat(CalendarUtil.getAttendeePartStat(
+                    calDavClient.getCalendarEvent(bob, organizerEventUri), alice.email()))
+                .as("Alice PARTSTAT on Bob organizer calendar before David delegated update")
+                .isEqualTo(PartStat.NEEDS_ACTION);
+            softly.assertThat(CalendarUtil.getAttendeePartStat(
+                    calDavClient.getCalendarEvent(alice, aliceEventUri), alice.email()))
+                .as("Alice PARTSTAT on Alice attendee calendar before David delegated update")
+                .isEqualTo(PartStat.NEEDS_ACTION);
+        }));
+
+        // AND Alice delegates her calendar to David with READ only
+        calDavClient.grantDelegation(alice, alice.id(), david, DelegationRight.READ);
+        CalendarURL delegatedCalendarURL = awaitAtMost.until(
+                () -> calDavClient.findUserCalendars(david)
+                    .filter(url -> !url.base().equals(url.calendarId()))
+                    .next().blockOptional(),
+                Optional::isPresent)
+            .orElseThrow(() -> new AssertionError("Expected Alice delegated calendar to be present for David"));
+
+        // AND David finds the event through his delegated calendar URI
+        URI delegatedEventUri = awaitAtMost.until(
+                () -> calDavClient.findFirstUserCalendarObjectUriByEventUid(david, delegatedCalendarURL, eventUid),
+                Optional::isPresent)
+            .orElseThrow(() -> new AssertionError("Expected event to be present in David delegated calendar"));
+        assertThat(delegatedEventUri.toASCIIString()).startsWith(delegatedCalendarURL.asUri().toASCIIString() + "/");
+
+        // WHEN David accepts Alice's participation via his delegated read-only calendar
+        String delegatedEventIcs = calDavClient.getCalendarEvent(david, delegatedEventUri);
+        assertThat(CalendarUtil.getAttendeePartStat(delegatedEventIcs, alice.email()))
+            .as("Alice PARTSTAT on David's delegated calendar before update")
+            .isEqualTo(PartStat.NEEDS_ACTION);
+        String acceptedDelegatedEventIcs = CalendarUtil.withAttendeePartStat(delegatedEventIcs, alice.email(), PartStat.ACCEPTED);
+        int delegatedUpdateStatus = executeNoContent(dockerExtension().davHttpClient()
+            .headers(headers -> david.impersonatedBasicAuth(headers)
+                .add("Content-Type", "text/calendar ; charset=utf-8"))
+            .put()
+            .uri(delegatedEventUri.toASCIIString())
+            .send(body(acceptedDelegatedEventIcs)));
+
+        // THEN Bob's organizer calendar keeps Alice participation untouched
+        Awaitility.await()
+            .during(Duration.ofSeconds(2))
+            .untilAsserted(() -> assertSoftly(softly -> {
+                softly.assertThat(delegatedUpdateStatus)
+                    .as("Read-only delegated PARTSTAT update should be rejected")
+                    .isEqualTo(403);
+                softly.assertThat(CalendarUtil.getAttendeePartStat(
+                        calDavClient.getCalendarEvent(bob, organizerEventUri), alice.email()))
+                    .as("Alice PARTSTAT on Bob organizer calendar after David delegated update")
+                    .isEqualTo(PartStat.NEEDS_ACTION);
+            }));
     }
 
     @Test

--- a/src/test/java/com/linagora/dav/contracts/cal/CalendarSharingContract.java
+++ b/src/test/java/com/linagora/dav/contracts/cal/CalendarSharingContract.java
@@ -21,6 +21,7 @@ package com.linagora.dav.contracts.cal;
 import static com.linagora.dav.CalendarAssert.assertThatCalendar;
 import static com.linagora.dav.TestUtil.body;
 import static com.linagora.dav.TestUtil.execute;
+import static com.linagora.dav.TestUtil.executeNoContent;
 import static io.restassured.RestAssured.given;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
@@ -2622,6 +2623,73 @@ public abstract class CalendarSharingContract {
             .isInstanceOf(RuntimeException.class)
             .hasMessageContaining("Unexpected status code: 403")
             .hasMessageContaining("User did not have the required privileges");
+    }
+
+    @Test
+    public void deleteFromReadPublicSubscribedCalendarShouldNotDeleteOriginCalendar() {
+        // GIVEN: Bob sets his calendar as read-only
+        calDavClient.updateCalendarAcl(bob, "{DAV:}read");
+
+        // AND: Bob has an event in his origin calendar
+        String eventUid = "event-" + UUID.randomUUID();
+        String calendarData = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Example Corp.//CalDAV Client//EN
+            BEGIN:VEVENT
+            UID:%s
+            DTSTAMP:20250929T080000Z
+            DTSTART:20251008T090000Z
+            DTEND:20251008T100000Z
+            SUMMARY:Bob's origin event
+            DESCRIPTION:Event to verify origin deletion safety
+            END:VEVENT
+            END:VCALENDAR
+            """.formatted(eventUid);
+
+        calDavClient.upsertCalendarEvent(bob, eventUid, calendarData);
+
+        // AND: Alice subscribes to Bob's readonly calendar
+        String subscribedCalendarId = UUID.randomUUID().toString();
+        SubscribedCalendarRequest subscribedCalendarRequest = SubscribedCalendarRequest.builder()
+            .id(subscribedCalendarId)
+            .sourceUserId(bob.id())
+            .name("Bob readonly mirror")
+            .color("#00FF00")
+            .readOnly(true)
+            .build();
+
+        CalendarURL mirrorCalendarURL = calDavClient.subscribeToSharedCalendar(alice, subscribedCalendarRequest);
+        assertThat(mirrorCalendarURL.asUri().toASCIIString())
+            .isEqualTo("/calendars/" + alice.id() + "/" + subscribedCalendarId);
+
+        // AND: Alice finds the event through her mirror calendar URI, not Bob's origin calendar URI
+        URI mirrorEventUri = awaitAtMost.until(() -> calDavClient.findFirstUserCalendarObjectUriByEventUid(alice, mirrorCalendarURL, eventUid),
+                Optional::isPresent)
+            .orElseThrow(() -> new AssertionError("Expected event to be present in Alice subscribed calendar"));
+        assertThat(mirrorEventUri.toASCIIString()).startsWith(mirrorCalendarURL.asUri().toASCIIString() + "/");
+
+        // WHEN: Alice deletes the event via the mirror calendar
+        int mirrorDeleteStatus = executeNoContent(extension().davHttpClient()
+            .headers(headers -> alice.impersonatedBasicAuth(headers)
+                .add("Content-Type", "text/calendar ; charset=utf-8"))
+            .delete()
+            .uri(mirrorEventUri.toASCIIString()));
+
+        // AND: Bob's origin calendar object must remain
+        URI originEventUri = URI.create("/calendars/" + bob.id() + "/" + bob.id() + "/" + eventUid + ".ics");
+        DavResponse originEventResponse = execute(extension().davHttpClient()
+            .headers(headers -> bob.impersonatedBasicAuth(headers)
+                .add("Content-Type", "text/calendar ; charset=utf-8"))
+            .get()
+            .uri(originEventUri.toASCIIString()));
+
+        assertThat(originEventResponse.status())
+            .as("Origin calendar event must remain when mirror DELETE returned " + mirrorDeleteStatus)
+            .isEqualTo(200);
+        assertThat(originEventResponse.body())
+            .contains(eventUid)
+            .contains("SUMMARY:Bob's origin event");
     }
 
     @Test

--- a/src/test/java/com/linagora/dav/contracts/cal/CalendarSharingContract.java
+++ b/src/test/java/com/linagora/dav/contracts/cal/CalendarSharingContract.java
@@ -2461,7 +2461,7 @@ public abstract class CalendarSharingContract {
     }
 
     @Test
-    public void partStatUpdateFromReadPublicSubscribedAttendeeCalendarShouldNotPropagateToOrganizerCalendar() {
+    protected void partStatUpdateFromReadPublicSubscribedAttendeeCalendarShouldNotPropagateToOrganizerCalendar() {
         OpenPaasUser david = extension().newTestUser();
 
         // GIVEN: Bob is the organizer of an event with Alice as attendee
@@ -2721,6 +2721,7 @@ public abstract class CalendarSharingContract {
             .hasMessageContaining("User did not have the required privileges");
     }
 
+    @Disabled("Wait to a new esn-sabre image")
     @Test
     public void deleteFromReadPublicSubscribedCalendarShouldNotDeleteOriginCalendar() {
         // GIVEN: Bob sets his calendar as read-only

--- a/src/test/java/com/linagora/dav/contracts/cal/CalendarSharingContract.java
+++ b/src/test/java/com/linagora/dav/contracts/cal/CalendarSharingContract.java
@@ -26,6 +26,7 @@ import static io.restassured.RestAssured.given;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import java.io.IOException;
 import java.net.URI;
@@ -54,6 +55,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linagora.dav.AmqpTestHelper;
 import com.linagora.dav.CalDavClient;
 import com.linagora.dav.CalendarURL;
+import com.linagora.dav.CalendarUtil;
 import com.linagora.dav.DavResponse;
 import com.linagora.dav.DockerTwakeCalendarExtension;
 import com.linagora.dav.DockerTwakeCalendarSetup;
@@ -70,6 +72,7 @@ import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.config.EncoderConfig;
 import io.restassured.config.RestAssuredConfig;
 import io.restassured.http.ContentType;
+import net.fortuna.ical4j.model.parameter.PartStat;
 
 public abstract class CalendarSharingContract {
 
@@ -2458,6 +2461,99 @@ public abstract class CalendarSharingContract {
     }
 
     @Test
+    public void partStatUpdateFromReadPublicSubscribedAttendeeCalendarShouldNotPropagateToOrganizerCalendar() {
+        OpenPaasUser david = extension().newTestUser();
+
+        // GIVEN: Bob is the organizer of an event with Alice as attendee
+        String eventUid = "event-" + UUID.randomUUID();
+        String calendarData = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Example Corp.//CalDAV Client//EN
+            BEGIN:VEVENT
+            UID:%s
+            DTSTAMP:20250929T080000Z
+            DTSTART:20251008T090000Z
+            DTEND:20251008T100000Z
+            SUMMARY:Bob organizer event
+            ORGANIZER;CN=Bob:mailto:%s
+            ATTENDEE;PARTSTAT=ACCEPTED;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:%s
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL;CN=Alice:mailto:%s
+            END:VEVENT
+            END:VCALENDAR
+            """.formatted(eventUid, bob.email(), bob.email(), alice.email());
+
+        calDavClient.upsertCalendarEvent(bob, eventUid, calendarData);
+
+        URI organizerEventUri = URI.create("/calendars/" + bob.id() + "/" + bob.id() + "/" + eventUid + ".ics");
+
+        // AND: Alice receives the invited event in her own calendar
+        CalendarURL aliceDefaultCalendarURL = CalendarURL.from(alice.id());
+        URI aliceEventUri = awaitAtMost.until(() -> calDavClient.findFirstUserCalendarObjectUriByEventUid(alice, aliceDefaultCalendarURL, eventUid),
+                Optional::isPresent)
+            .orElseThrow(() -> new AssertionError("Expected invited event to be present in Alice calendar"));
+        awaitAtMost.untilAsserted(() -> {
+            assertThat(CalendarUtil.getAttendeePartStat(
+                    calDavClient.getCalendarEvent(bob, organizerEventUri), alice.email()))
+                .as("Alice PARTSTAT on Bob organizer calendar before David mirror update")
+                .isEqualTo(PartStat.NEEDS_ACTION);
+            assertThat(CalendarUtil.getAttendeePartStat(
+                    calDavClient.getCalendarEvent(alice, aliceEventUri), alice.email()))
+                .as("Alice PARTSTAT on Alice attendee calendar before David mirror update")
+                .isEqualTo(PartStat.NEEDS_ACTION);
+        });
+
+        // AND: Alice exposes her calendar as read-only public calendar
+        calDavClient.updateCalendarAcl(alice, "{DAV:}read");
+
+        // AND: David subscribes to Alice's readonly calendar
+        String subscribedCalendarId = UUID.randomUUID().toString();
+        SubscribedCalendarRequest subscribedCalendarRequest = SubscribedCalendarRequest.builder()
+            .id(subscribedCalendarId)
+            .sourceUserId(alice.id())
+            .name("Alice readonly mirror")
+            .color("#00FF00")
+            .readOnly(true)
+            .build();
+
+        CalendarURL mirrorCalendarURL = calDavClient.subscribeToSharedCalendar(david, subscribedCalendarRequest);
+        assertThat(mirrorCalendarURL.asUri().toASCIIString())
+            .isEqualTo("/calendars/" + david.id() + "/" + subscribedCalendarId);
+
+        // AND: David finds the event through his mirror calendar URI, not Alice's attendee calendar URI
+        URI mirrorEventUri = awaitAtMost.until(() -> calDavClient.findFirstUserCalendarObjectUriByEventUid(david, mirrorCalendarURL, eventUid),
+                Optional::isPresent)
+            .orElseThrow(() -> new AssertionError("Expected event to be present in David subscribed calendar"));
+        assertThat(mirrorEventUri.toASCIIString()).startsWith(mirrorCalendarURL.asUri().toASCIIString() + "/");
+
+        // WHEN: David accepts Alice's participation via his subscribed mirror calendar
+        String mirrorEventIcs = calDavClient.getCalendarEvent(david, mirrorEventUri);
+        assertThat(CalendarUtil.getAttendeePartStat(mirrorEventIcs, alice.email()))
+            .as("Alice PARTSTAT on David's subscribed mirror calendar before update")
+            .isEqualTo(PartStat.NEEDS_ACTION);
+        String acceptedMirrorEventIcs = CalendarUtil.withAttendeePartStat(mirrorEventIcs, alice.email(), PartStat.ACCEPTED);
+        int mirrorUpdateStatus = executeNoContent(extension().davHttpClient()
+            .headers(headers -> david.impersonatedBasicAuth(headers)
+                .add("Content-Type", "text/calendar ; charset=utf-8"))
+            .put()
+            .uri(mirrorEventUri.toASCIIString())
+            .send(body(acceptedMirrorEventIcs)));
+
+        // THEN: Bob's organizer calendar keeps Alice participation untouched
+        calmlyAwait
+            .during(2, TimeUnit.SECONDS)
+            .untilAsserted(() -> assertSoftly(softly -> {
+                softly.assertThat(mirrorUpdateStatus)
+                    .as("Read-only mirror PARTSTAT update should be rejected")
+                    .isEqualTo(403);
+                softly.assertThat(CalendarUtil.getAttendeePartStat(
+                        calDavClient.getCalendarEvent(bob, organizerEventUri), alice.email()))
+                    .as("Alice PARTSTAT on Bob organizer calendar after David mirror update")
+                    .isEqualTo(PartStat.NEEDS_ACTION);
+            }));
+    }
+
+    @Test
     public void nativeUpsertShouldBeAcceptedOnWritePublicCalender() {
         // GIVEN: Bob sets his calendar as read-write
         calDavClient.updateCalendarAcl(bob, "{DAV:}write");
@@ -2684,12 +2780,17 @@ public abstract class CalendarSharingContract {
             .get()
             .uri(originEventUri.toASCIIString()));
 
-        assertThat(originEventResponse.status())
-            .as("Origin calendar event must remain when mirror DELETE returned " + mirrorDeleteStatus)
-            .isEqualTo(200);
-        assertThat(originEventResponse.body())
-            .contains(eventUid)
-            .contains("SUMMARY:Bob's origin event");
+        assertSoftly(softly -> {
+            softly.assertThat(mirrorDeleteStatus)
+                .as("Read-only mirror DELETE should be rejected")
+                .isEqualTo(403);
+            softly.assertThat(originEventResponse.status())
+                .as("Origin calendar event must remain when mirror DELETE returned " + mirrorDeleteStatus)
+                .isEqualTo(200);
+            softly.assertThat(originEventResponse.body())
+                .contains(eventUid)
+                .contains("SUMMARY:Bob's origin event");
+        });
     }
 
     @Test

--- a/src/test/java/com/linagora/dav/sabrev4/cal/SabreV4CalendarSharingTest.java
+++ b/src/test/java/com/linagora/dav/sabrev4/cal/SabreV4CalendarSharingTest.java
@@ -108,4 +108,11 @@ public class SabreV4CalendarSharingTest extends CalendarSharingContract {
     @Test
     public void adminShouldBeAbleToModifyResourceEventsWhenDeletingSubscriptionAndThenSubscribingAgain() {
     }
+
+    @Disabled("Fixed in sabre 4.7")
+    @Override
+    @Test
+    public void partStatUpdateFromReadPublicSubscribedAttendeeCalendarShouldNotPropagateToOrganizerCalendar() {
+
+    }
 }

--- a/src/test/java/com/linagora/dav/sabrev4/cal/SabreV4CalendarSharingTest.java
+++ b/src/test/java/com/linagora/dav/sabrev4/cal/SabreV4CalendarSharingTest.java
@@ -85,6 +85,12 @@ public class SabreV4CalendarSharingTest extends CalendarSharingContract {
         super.nativeDeleteShouldBeRejectedOnReadPublicCalender();
     }
 
+    @Disabled("https://github.com/linagora/esn-sabre/issues/347")
+    @Override
+    public void deleteFromReadPublicSubscribedCalendarShouldNotDeleteOriginCalendar() {
+        super.deleteFromReadPublicSubscribedCalendarShouldNotDeleteOriginCalendar();
+    }
+
     @Disabled("https://github.com/linagora/esn-sabre/issues/61")
     @Override
     public void nativeDeleteShouldBeAcceptedOnWritePublicCalender() {


### PR DESCRIPTION
relate 
- https://github.com/linagora/esn-sabre/issues/347