### PR TITLE
perf(ci): remove unused Docker image pull (twake-calendar-side-service:branch-master)

### DIFF
--- a/pre-build.sh
+++ b/pre-build.sh
@@ -16,6 +16,5 @@ else
   docker build --pull -t sabre-v4-7-it -f Dockerfile.sabre4_7 .
 fi
 
-docker pull linagora/twake-calendar-side-service:branch-master
 docker build -t tcalendar-it -f Dockerfile.tcalendar .
 docker build -t ldap-it -f Dockerfile.ldap .


### PR DESCRIPTION
we already use image by tag twake-calendar-side-service:2.1.0