### PR TITLE
fix(dav): retry technical token provisioning requests

### DIFF
--- a/src/test/java/com/linagora/dav/CalDavClient.java
+++ b/src/test/java/com/linagora/dav/CalDavClient.java
@@ -18,6 +18,8 @@
 
 package com.linagora.dav;
 
+import static com.linagora.dav.CardDavClient.TWAKE_CALENDAR_TOKEN_HEADER;
+import static com.linagora.dav.CardDavClient.retryTechnicalTokenRequest;
 import static com.linagora.dav.TestUtil.body;
 
 import java.net.URI;
@@ -40,6 +42,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Streams;
 import com.google.common.xml.XmlEscapers;
+import com.linagora.dav.CardDavClient.RetryableRequestException;
 import com.linagora.dav.dto.share.SubscribedCalendarRequest;
 
 import io.netty.buffer.Unpooled;
@@ -155,7 +158,7 @@ public class CalDavClient {
     }
 
     public void upsertCalendarEvent(String entityId, String eventId, String calendarData, String token) {
-        httpClient.headers(headers -> headers.add("TwakeCalendarToken", token))
+        httpClient.headers(headers -> headers.add(TWAKE_CALENDAR_TOKEN_HEADER, token))
             .put()
             .uri("/calendars/" + entityId + "/" + entityId + "/" + eventId + ".ics")
             .send(TestUtil.body(calendarData))
@@ -163,13 +166,18 @@ public class CalDavClient {
                 if (response.status().code() == 201 || response.status().code() == 204) {
                     return Mono.empty();
                 }
+                if (response.status().code() == 401) {
+                    return Mono.error(new RetryableRequestException());
+                }
                 return responseContent.asString(StandardCharsets.UTF_8)
                     .switchIfEmpty(Mono.just(StringUtils.EMPTY))
                     .flatMap(responseBody -> Mono.error(new RuntimeException("""
                         Unexpected status code: %d when create/update calendar object
                         %s
                         """.formatted(response.status().code(), responseBody))));
-            }).block();
+            })
+            .retryWhen(retryTechnicalTokenRequest())
+            .block();
     }
 
     public void upsertJsonCalendarEvent(OpenPaasUser openPaasUser, String eventId, String calendarData) {
@@ -196,12 +204,15 @@ public class CalDavClient {
     }
 
     public String getCalendarEvent(String entityId, String eventId, String token) {
-        return httpClient.headers(headers -> headers.add("TwakeCalendarToken", token))
+        return httpClient.headers(headers -> headers.add(TWAKE_CALENDAR_TOKEN_HEADER, token))
             .get()
             .uri("/calendars/" + entityId + "/" + entityId + "/" + eventId + ".ics")
             .responseSingle((response, responseContent) -> {
                 if (response.status().code() == 200) {
                     return responseContent.asByteArray().map(bytes -> new String(bytes, StandardCharsets.UTF_8));
+                }
+                if (response.status().code() == 401) {
+                    return Mono.error(new RetryableRequestException());
                 }
                 return responseContent.asString(StandardCharsets.UTF_8)
                     .switchIfEmpty(Mono.just(StringUtils.EMPTY))
@@ -209,7 +220,9 @@ public class CalDavClient {
                         Unexpected status code: %d when create/update calendar object
                         %s
                         """.formatted(response.status().code(), responseBody))));
-            }).block();
+            })
+            .retryWhen(retryTechnicalTokenRequest())
+            .block();
     }
 
     public String getCalendarEvent(OpenPaasUser userRequest, URI calendarURI) {
@@ -473,6 +486,25 @@ public class CalDavClient {
         grantDelegations(entityId, Map.of(delegatedUser, right), token);
     }
 
+    public void revokeDelegation(String entityId, OpenPaasUser delegatedUser, String token) {
+        String uri = "/calendars/" + entityId + "/" + entityId + ".json";
+
+        String payload = """
+            {
+              "share": {
+                "set": [],
+                "remove": [
+                  {
+                    "dav:href": "mailto:{email}"
+                  }
+                ]
+              }
+            }
+            """.replace("{email}", delegatedUser.email());
+
+        sendDelegationRequest(uri, payload, token);
+    }
+
     public void grantDelegations(String entityId, Map<OpenPaasUser, DelegationRight> delegations, String token) {
         String uri = "/calendars/" + entityId + "/" + entityId + ".json";
 
@@ -497,15 +529,7 @@ public class CalDavClient {
             }
             """.replace("{entries}", setEntries);
 
-        try{
-            sendDelegationRequest(uri, payload, token);
-        } catch (Exception e) {
-            if (e.getMessage().contains("Could not find node at path:")) {    // Retry once on first creation because DAV data not be provisioned yet.
-                sendDelegationRequest(uri, payload, token);
-            } else {
-                throw e;
-            }
-        }
+        sendDelegationRequest(uri, payload, token);
     }
 
     public DavResponse findEventsByTime(OpenPaasUser user, String start, String end) {
@@ -558,7 +582,7 @@ public class CalDavClient {
                 .add(HttpHeaderNames.ACCEPT, "application/json, text/plain, */*"))
             .request(HttpMethod.POST)
             .uri(uri)
-            .send(Mono.just(Unpooled.wrappedBuffer(payload.getBytes(StandardCharsets.UTF_8))))
+            .send(Mono.fromCallable(() -> Unpooled.wrappedBuffer(payload.getBytes(StandardCharsets.UTF_8))))
             .responseSingle((response, responseContent) -> {
                 if (response.status().code() == 200) {
                     return Mono.empty();
@@ -573,15 +597,18 @@ public class CalDavClient {
     }
 
     private void sendDelegationRequest(String uri, String payload, String token) {
-        httpClient.headers(headers -> headers.add("TwakeCalendarToken", token)
+        httpClient.headers(headers -> headers.add(TWAKE_CALENDAR_TOKEN_HEADER, token)
                 .add(HttpHeaderNames.CONTENT_TYPE, "application/json;charset=UTF-8")
                 .add(HttpHeaderNames.ACCEPT, "application/json, text/plain, */*"))
             .request(HttpMethod.POST)
             .uri(uri)
-            .send(Mono.just(Unpooled.wrappedBuffer(payload.getBytes(StandardCharsets.UTF_8))))
+            .send(Mono.fromCallable(() -> Unpooled.wrappedBuffer(payload.getBytes(StandardCharsets.UTF_8))))
             .responseSingle((response, responseContent) -> {
                 if (response.status().code() == 200) {
                     return Mono.empty();
+                }
+                if (response.status().code() == 401 || response.status().code() == 404) {
+                    return Mono.error(new RetryableRequestException());
                 }
                 return responseContent.asString(StandardCharsets.UTF_8)
                     .switchIfEmpty(Mono.just(StringUtils.EMPTY))
@@ -589,7 +616,9 @@ public class CalDavClient {
                         Unexpected status code: %d when sharing calendar '%s'
                         %s
                         """.formatted(response.status().code(), uri, errorBody))));
-            }).block();
+            })
+            .retryWhen(retryTechnicalTokenRequest())
+            .block();
     }
 
     private List<CalendarURL> extractCalendarURLsFromResponse(String json) {

--- a/src/test/java/com/linagora/dav/CardDavClient.java
+++ b/src/test/java/com/linagora/dav/CardDavClient.java
@@ -74,6 +74,20 @@ public class CardDavClient {
         }
     }
 
+    public static Retry retryTechnicalTokenRequest() {
+        return Retry.fixedDelay(1, Duration.ofMillis(500))
+            .filter(RetryableRequestException.class::isInstance)
+            .onRetryExhaustedThrow((retryBackoffSpec, retrySignal) -> retrySignal.failure());
+    }
+
+    public static class RetryableRequestException extends RuntimeException {
+        RetryableRequestException() {
+            super();
+        }
+    }
+
+    public static final String TWAKE_CALENDAR_TOKEN_HEADER = "TwakeCalendarToken";
+
     private static final String CONTENT_TYPE_VCARD = "application/vcard+json";
     private static final String ACCEPT_VCARD_JSON = "application/json, text/plain, */*";
     private static final String ADDRESS_BOOK_PATH = "/addressbooks/%s/%s/%s.vcf";
@@ -95,7 +109,7 @@ public class CardDavClient {
                 .add(HttpHeaderNames.ACCEPT, ACCEPT_VCARD_JSON))
             .put()
             .uri(String.format(ADDRESS_BOOK_PATH, baseId, addressBook, vcardUid))
-            .send(Mono.just(Unpooled.wrappedBuffer(vcardPayload)))
+            .send(Mono.fromCallable(() -> Unpooled.wrappedBuffer(vcardPayload)))
             .responseSingle((response, byteBufMono) ->
                 handleContactUpsertResponse(response, byteBufMono, openPaasUser, addressBook, vcardUid))
             .block();
@@ -254,20 +268,26 @@ public class CardDavClient {
 
     public void deleteAddressBook(String baseId, String addressBookId, String technicalToken) {
         String uri = String.format("/addressbooks/%s/%s.json", baseId, addressBookId);
-        client.headers(headers -> headers.add("TwakeCalendarToken", technicalToken)
+        client.headers(headers -> headers.add(TWAKE_CALENDAR_TOKEN_HEADER, technicalToken)
                 .add(HttpHeaderNames.ACCEPT, "application/vcard+json"))
             .delete()
             .uri(uri)
             .responseSingle((response, buf) -> {
-                if (response.status().code() == 204 || response.status().code() == 404) {
+                int status = response.status().code();
+                if (status == 204 || status == 404) {
                     return Mono.empty();
+                }
+                if (status == 401) {
+                    return Mono.error(new RetryableRequestException());
                 }
                 return buf.asString(StandardCharsets.UTF_8)
                     .switchIfEmpty(Mono.just(StringUtils.EMPTY))
                     .flatMap(errorBody -> Mono.error(new RuntimeException(
                         "Unexpected status code: %d when deleting address book %s with baseId %s\n%s"
-                            .formatted(response.status().code(), addressBookId, baseId, errorBody))));
-            }).block();
+                            .formatted(status, addressBookId, baseId, errorBody))));
+            })
+            .retryWhen(retryTechnicalTokenRequest())
+            .block();
     }
 
     public void grantDelegation(OpenPaasUser user, String addressBookId, OpenPaasUser delegatedUser, DelegationRight right) {
@@ -525,7 +545,7 @@ public class CardDavClient {
             """.getBytes(StandardCharsets.UTF_8);
 
         client.headers(headers -> headers
-                .add("TwakeCalendarToken", technicalToken)
+                .add(TWAKE_CALENDAR_TOKEN_HEADER, technicalToken)
                 .add(HttpHeaderNames.CONTENT_TYPE, "application/json;charset=UTF-8")
                 .add(HttpHeaderNames.ACCEPT, "application/json"))
             .post()
@@ -536,8 +556,8 @@ public class CardDavClient {
                 if (status == 201) {
                     return Mono.empty();
                 }
-                if (status == 404) {
-                    return Mono.error(new RuntimeException("__RETRY__"));
+                if (status == 401 || status == 404) {
+                    return Mono.error(new RetryableRequestException());
                 }
 
                 return buf.asString(StandardCharsets.UTF_8)
@@ -553,8 +573,7 @@ public class CardDavClient {
                             """.formatted(domainId, status, body)));
                     });
             })
-            .retryWhen(Retry.fixedDelay(1, Duration.ofMillis(500))
-                .filter(err -> err.getMessage() != null && err.getMessage().contains("__RETRY__")))
+            .retryWhen(retryTechnicalTokenRequest())
             .then()
             .block();
     }
@@ -565,17 +584,20 @@ public class CardDavClient {
                                           String technicalToken) {
         String uri = String.format("/addressbooks/%s/domain-members/%s.vcf", domainId, vcardUid);
         client.headers(headers -> headers
-                .add("TwakeCalendarToken", technicalToken)
+                .add(TWAKE_CALENDAR_TOKEN_HEADER, technicalToken)
                 .add(HttpHeaderNames.CONTENT_TYPE, CONTENT_TYPE_VCARD)
                 .add(HttpHeaderNames.ACCEPT, ACCEPT_VCARD_JSON))
             .put()
             .uri(uri)
-            .send(Mono.just(Unpooled.wrappedBuffer(vcardPayload)))
+            .send(Mono.fromCallable(() -> Unpooled.wrappedBuffer(vcardPayload)))
             .responseSingle((response, buf) -> {
                 int status = response.status().code();
 
                 if (status == 201 || status == 204) {
                     return Mono.empty();
+                }
+                if (status == 401) {
+                    return Mono.error(new RetryableRequestException());
                 }
 
                 return buf.asString(StandardCharsets.UTF_8)
@@ -587,13 +609,14 @@ public class CardDavClient {
                         Response: %s
                         """.formatted(status, domainId, vcardUid, body))));
             })
+            .retryWhen(retryTechnicalTokenRequest())
             .block();
     }
 
     public void deleteContactDomainMembers(String domainId, String vcardUid, String technicalToken) {
         String uri = String.format(ADDRESS_BOOK_PATH, domainId, "domain-members", vcardUid);
         client.headers(headers -> headers
-                .add("TwakeCalendarToken", technicalToken)
+                .add(TWAKE_CALENDAR_TOKEN_HEADER, technicalToken)
                 .add(HttpHeaderNames.ACCEPT, ACCEPT_VCARD_JSON))
             .delete()
             .uri(uri)
@@ -601,6 +624,9 @@ public class CardDavClient {
                 int statusCode = response.status().code();
                 if (statusCode == 204) {
                     return Mono.empty();
+                }
+                if (statusCode == 401) {
+                    return Mono.error(new RetryableRequestException());
                 }
 
                 return buf.asString(StandardCharsets.UTF_8)
@@ -614,6 +640,7 @@ public class CardDavClient {
                             statusCode, domainId, vcardUid, body)));
                     });
             })
+            .retryWhen(retryTechnicalTokenRequest())
             .block();
     }
 
@@ -631,7 +658,7 @@ public class CardDavClient {
             """.getBytes(StandardCharsets.UTF_8);
 
         client.headers(headers -> headers
-                .add("TwakeCalendarToken", technicalToken)
+                .add(TWAKE_CALENDAR_TOKEN_HEADER, technicalToken)
                 .add(HttpHeaderNames.CONTENT_TYPE, "application/json;charset=UTF-8")
                 .add(HttpHeaderNames.ACCEPT, "application/json"))
             .post()
@@ -642,8 +669,8 @@ public class CardDavClient {
                 if (status == 201) {
                     return Mono.empty();
                 }
-                if (status == 404) {
-                    return Mono.error(new RuntimeException("__RETRY__"));
+                if (status == 401 || status == 404) {
+                    return Mono.error(new RetryableRequestException());
                 }
 
                 return buf.asString(StandardCharsets.UTF_8)
@@ -659,8 +686,7 @@ public class CardDavClient {
                             """.formatted(domainId, status, body)));
                     });
             })
-            .retryWhen(Retry.fixedDelay(1, Duration.ofMillis(500))
-                .filter(err -> err.getMessage() != null && err.getMessage().contains("__RETRY__")))
+            .retryWhen(retryTechnicalTokenRequest())
             .then()
             .block();
     }
@@ -671,17 +697,20 @@ public class CardDavClient {
                                     String technicalToken) {
         String uri = String.format("/addressbooks/%s/dab/%s.vcf", domainId, vcardUid);
         client.headers(headers -> headers
-                .add("TwakeCalendarToken", technicalToken)
+                .add(TWAKE_CALENDAR_TOKEN_HEADER, technicalToken)
                 .add(HttpHeaderNames.CONTENT_TYPE, CONTENT_TYPE_VCARD)
                 .add(HttpHeaderNames.ACCEPT, ACCEPT_VCARD_JSON))
             .put()
             .uri(uri)
-            .send(Mono.just(Unpooled.wrappedBuffer(vcardPayload)))
+            .send(Mono.fromCallable(() -> Unpooled.wrappedBuffer(vcardPayload)))
             .responseSingle((response, buf) -> {
                 int status = response.status().code();
 
                 if (status == 201 || status == 204) {
                     return Mono.empty();
+                }
+                if (status == 401) {
+                    return Mono.error(new RetryableRequestException());
                 }
 
                 return buf.asString(StandardCharsets.UTF_8)
@@ -692,6 +721,8 @@ public class CardDavClient {
                         UID: %s
                         Response: %s
                         """.formatted(status, domainId, vcardUid, body))));
-            }).block();
+            })
+            .retryWhen(retryTechnicalTokenRequest())
+            .block();
     }
 }

--- a/src/test/java/com/linagora/dav/TestUtil.java
+++ b/src/test/java/com/linagora/dav/TestUtil.java
@@ -45,7 +45,7 @@ public class TestUtil {
 
     public static final boolean DEBUG = true;
     public static Mono<ByteBuf> body(String body) {
-        return Mono.just(Unpooled.wrappedBuffer(body.getBytes(StandardCharsets.UTF_8)));
+        return Mono.fromCallable(() -> Unpooled.wrappedBuffer(body.getBytes(StandardCharsets.UTF_8)));
     }
 
     public static DavResponse execute(HttpClient.ResponseReceiver<?> client) {

--- a/src/test/java/com/linagora/dav/contracts/cal/CalDavContract.java
+++ b/src/test/java/com/linagora/dav/contracts/cal/CalDavContract.java
@@ -2306,12 +2306,6 @@ public abstract class CalDavContract {
 
         String token = dockerExtension().twakeCalendarProvisioningService().generateToken();
 
-        // To ensure calendar directory is activated
-        try {
-            calDavClient.getCalendarEvent(resource.id(), resourceEventId, token);
-        } catch (Exception ignored) {
-        }
-
         String actual = calDavClient.getCalendarEvent(resource.id(), resourceEventId, token);
         Calendar actualCalendar = CalendarUtil.parseIcs(actual);
         actualCalendar.removeAll(Property.PRODID);
@@ -2377,12 +2371,6 @@ public abstract class CalDavContract {
 
         String token = dockerExtension().twakeCalendarProvisioningService().generateToken();
 
-        // To ensure calendar directory is activated
-        try {
-            calDavClient.getCalendarEvent(resource.id(), resourceEventId, token);
-        } catch (Exception ignored) {
-        }
-
         String updatedCalendarData = generateCalendarDataWithResource(
             eventUid,
             testUser.email(),
@@ -2424,12 +2412,6 @@ public abstract class CalDavContract {
         String resourceEventId = awaitAtMost.until(() -> calDavClient.findFirstEventId(resource.id(), testUser), Optional::isPresent).get();
 
         String token = dockerExtension().twakeCalendarProvisioningService().generateToken();
-
-        // To ensure calendar directory is activated
-        try {
-            calDavClient.getCalendarEvent(resource.id(), resourceEventId, token);
-        } catch (Exception ignored) {
-        }
 
         String updatedCalendarData = generateCalendarDataWithResource(
             eventUid,

--- a/src/test/java/com/linagora/dav/contracts/cal/CalDavDelegationContract.java
+++ b/src/test/java/com/linagora/dav/contracts/cal/CalDavDelegationContract.java
@@ -26,11 +26,11 @@ import static com.linagora.dav.TestUtil.executeNoContent;
 import static com.linagora.dav.contracts.cal.ITIPRequestContract.awaitAtMost;
 import static io.restassured.RestAssured.given;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -44,7 +44,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
-import org.apache.commons.lang3.StringUtils;
 import org.assertj.core.api.AssertionsForClassTypes;
 import org.assertj.core.api.AssertionsForInterfaceTypes;
 import org.junit.jupiter.api.BeforeEach;
@@ -87,7 +86,6 @@ import net.fortuna.ical4j.model.Property;
 import net.fortuna.ical4j.model.component.VEvent;
 import net.fortuna.ical4j.model.parameter.PartStat;
 import reactor.core.publisher.Mono;
-import reactor.util.retry.Retry;
 
 public abstract class CalDavDelegationContract {
 
@@ -3156,86 +3154,11 @@ public abstract class CalDavDelegationContract {
     }
 
     private void delegateResourceToAdmin(OpenPaaSResource resource, OpenPaasUser admin, String technicalToken) {
-        Map.Entry<Integer, String> delegationResponse = dockerExtension().davHttpClient()
-            .headers(headers -> headers
-                .add("TwakeCalendarToken", technicalToken)
-                .add(HttpHeaderNames.CONTENT_TYPE, "application/json;charset=UTF-8")
-                .add(HttpHeaderNames.ACCEPT, "application/json, text/plain, */*"))
-            .request(HttpMethod.POST)
-            .uri("/calendars/" + resource.id() + "/" + resource.id() + ".json")
-            .send(Mono.defer(() -> {
-                String payload = """
-                    {
-                      "share": {
-                        "set": [
-                          {
-                            "dav:href": "mailto:%s",
-                            "dav:read-write": true
-                          }
-                        ],
-                        "remove": []
-                      }
-                    }
-                    """.formatted(admin.email());
-                return Mono.just(Unpooled.wrappedBuffer(payload.getBytes(StandardCharsets.UTF_8)));
-            }))
-            .responseSingle((response, content) -> content.asString()
-                .defaultIfEmpty("")
-                .flatMap(body -> {
-                    int status = response.status().code();
-                    if (status != 200 && status != 201 && status != 204) {
-                        return Mono.error(new RuntimeException("HTTP " + status + ": " + body));
-                    }
-                    return Mono.just(Map.entry(status, body));
-                }))
-            .retryWhen(Retry.fixedDelay(1, Duration.ofSeconds(1))
-                .filter(error -> StringUtils.containsAnyIgnoreCase(error.getMessage(), "Could not find node at path")))
-            .block();
-
-        assertThat(delegationResponse.getKey())
-            .as("Bob should be granted write access to the resource calendar")
-            .isIn(200, 201, 204);
+        calDavClient.grantDelegation(resource.id(), admin, DelegationRight.READ_WRITE, technicalToken);
     }
 
     private void revokeResourceAdmin(OpenPaaSResource resource, OpenPaasUser admin, String technicalToken) {
-        Map.Entry<Integer, String> revocationResponse = dockerExtension().davHttpClient()
-            .headers(headers -> headers
-                .add("TwakeCalendarToken", technicalToken)
-                .add(HttpHeaderNames.CONTENT_TYPE, "application/json;charset=UTF-8")
-                .add(HttpHeaderNames.ACCEPT, "application/json, text/plain, */*"))
-            .request(HttpMethod.POST)
-            .uri("/calendars/" + resource.id() + "/" + resource.id() + ".json")
-            .send(Mono.defer(() -> {
-                String payload = """
-                    {
-                      "share": {
-                        "set": [],
-                        "remove": [
-                          {
-                            "dav:href": "mailto:%s"
-                          }
-                        ]
-                      }
-                    }
-                    """.formatted(admin.email());
-                return Mono.just(Unpooled.wrappedBuffer(payload.getBytes(StandardCharsets.UTF_8)));
-            }))
-            .responseSingle((response, content) -> content.asString()
-                .defaultIfEmpty("")
-                .flatMap(body -> {
-                    int status = response.status().code();
-                    if (status != 200 && status != 201 && status != 204) {
-                        return Mono.error(new RuntimeException("HTTP " + status + ": " + body));
-                    }
-                    return Mono.just(Map.entry(status, body));
-                }))
-            .retryWhen(Retry.fixedDelay(1, Duration.ofSeconds(1))
-                .filter(error -> StringUtils.containsAnyIgnoreCase(error.getMessage(), "Could not find node at path")))
-            .block();
-
-        assertThat(revocationResponse.getKey())
-            .as("Bob's write access on the resource calendar should be revoked")
-            .isIn(200, 201, 204);
+        calDavClient.revokeDelegation(resource.id(), admin, technicalToken);
     }
 
     @Test

--- a/src/test/java/com/linagora/dav/contracts/cal/CalendarSharingContract.java
+++ b/src/test/java/com/linagora/dav/contracts/cal/CalendarSharingContract.java
@@ -2403,11 +2403,6 @@ public abstract class CalendarSharingContract {
             .replace("{resourceId}", resource.id());
 
         String token = extension().twakeCalendarProvisioningService().generateToken();
-        // To ensure calendar directory is activated
-        try {
-            calDavClient.getCalendarEvent(resource.id(), resourceEventId, token);
-        } catch (Exception ignored) {
-        }
         calDavClient.upsertCalendarEvent(resource.id(), resourceEventId, updatedCalendarData, token);
 
         // THEN an AMQP message should be emitted for Alice's subscribed calendar (copy of resource calendar)

--- a/src/test/java/com/linagora/dav/contracts/cal/ResourceAMQPMessageContract.java
+++ b/src/test/java/com/linagora/dav/contracts/cal/ResourceAMQPMessageContract.java
@@ -175,12 +175,6 @@ public abstract class ResourceAMQPMessageContract {
 
         String token = dockerExtension().twakeCalendarProvisioningService().generateToken();
 
-        // To ensure calendar directory is activated
-        try {
-            calDavClient.getCalendarEvent(resource.id(), resourceEventId, token);
-        } catch (Exception ignored) {
-        }
-
         String updatedCalendarData = generateCalendarData(
             eventUid,
             testUser.email(),
@@ -282,12 +276,6 @@ public abstract class ResourceAMQPMessageContract {
         String resourceEventId = awaitAtMost.until(() -> calDavClient.findFirstEventId(resource.id(), testUser), Optional::isPresent).get();
 
         String token = dockerExtension().twakeCalendarProvisioningService().generateToken();
-
-        // To ensure calendar directory is activated
-        try {
-            calDavClient.getCalendarEvent(resource.id(), resourceEventId, token);
-        } catch (Exception ignored) {
-        }
 
         String updatedCalendarData = generateCalendarData(
             eventUid,


### PR DESCRIPTION
Retry CalDAV and CardDAV technical-token requests once when Sabre returns initial provisioning-related 401/404 responses. Centralize retry handling in DAV clients and remove test warm-up calls that hid the first-request failure.
___________

I'm not sure if this approach is correct.

It originates from an upstream Pull Request:
- https://github.com/linagora/esn-sabre/pull/357 

When the initial request is made using a Technical Calendar Token, it returns an HTTP 401 error code. However, from the second request onwards, this error no longer occurs.