### PR TITLE
test(caldav): cover resource admin impersonation access

### DIFF
--- a/src/test/java/com/linagora/dav/contracts/cal/CalDavContract.java
+++ b/src/test/java/com/linagora/dav/contracts/cal/CalDavContract.java
@@ -22,6 +22,7 @@ import static com.linagora.dav.CalendarAssert.assertThatCalendar;
 import static com.linagora.dav.TestUtil.body;
 import static com.linagora.dav.TestUtil.execute;
 import static com.linagora.dav.TestUtil.executeNoContent;
+import static com.linagora.dav.TwakeCalendarProvisioningService.DEFAULT_DOMAIN;
 import static com.linagora.dav.contracts.cal.CalendarSharingContract.MAPPER;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -72,6 +73,7 @@ import com.linagora.dav.TestUtil;
 import com.linagora.dav.TwakeCalendarEvent;
 import com.linagora.dav.XMLUtil;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import net.fortuna.ical4j.model.Calendar;
 import net.fortuna.ical4j.model.Component;
@@ -2345,6 +2347,41 @@ public abstract class CalDavContract {
             .replace("{organizerEmail}", testUser.email())
             .replace("{attendeeEmail}", testUser2.email())
             .replace("{resourceId}", resource.id()));
+    }
+
+    @Test
+    protected void resourceCalendarShouldBeAccessibleWhenAuthenticatedByAdminImpersonation() {
+        // Given a resource exists but its CalDAV calendar has not been accessed yet
+        OpenPaasUser testUser = dockerExtension().newTestUser();
+        OpenPaaSResource resource = dockerExtension().getDockerTwakeCalendarSetupSingleton()
+            .getTwakeCalendarProvisioningService()
+            .createResource("projector", "This is a projector", testUser)
+            .block();
+
+        String resourceEmail = resource.id() + "@" + DEFAULT_DOMAIN;
+
+        // When Sabre authenticates admin impersonation of the resource
+        DavResponse response = execute(dockerExtension().davHttpClient()
+            .headers(headers -> headers
+                .add(HttpHeaderNames.AUTHORIZATION, OpenPaasUser.impersonatedBasicAuth(resourceEmail))
+                .add(HttpHeaderNames.CONTENT_TYPE, "application/xml")
+                .add("Depth", "0"))
+            .request(HttpMethod.valueOf("PROPFIND"))
+            .uri("/calendars/" + resource.id() + "/" + resource.id())
+            .send(body("""
+                <d:propfind xmlns:d="DAV:">
+                    <d:prop>
+                        <d:resourcetype />
+                    </d:prop>
+                </d:propfind>
+                """)));
+
+        // Then the resource calendar is lazily provisioned without breaking authentication
+        assertThat(response.status())
+            .as("Admin impersonation of resource %s should access its default calendar", resourceEmail)
+            .isEqualTo(207);
+        assertThat(response.body())
+            .contains("/calendars/" + resource.id() + "/" + resource.id() + "/");
     }
 
     @Test

--- a/src/test/java/com/linagora/dav/sabrev4/cal/SabreV4CalDavTest.java
+++ b/src/test/java/com/linagora/dav/sabrev4/cal/SabreV4CalDavTest.java
@@ -58,4 +58,9 @@ class SabreV4CalDavTest extends CalDavContract {
     @Override
     protected void unauthenticatedRequestsShouldReturn401(AuthenticatedEndpoint input) {
     }
+
+    @Override
+    @Disabled("Supported only on Sabre 4.7")
+    protected void resourceCalendarShouldBeAccessibleWhenAuthenticatedByAdminImpersonation() {
+    }
 }


### PR DESCRIPTION
When running with the Docker image `linagora/esn-sabre:2.2.1`, I found an issue with PR:
- https://github.com/linagora/esn-sabre/pull/365
which we missed because we had not tested the admin-impersonates-resource case.

It returns a `401` error on the initial request, then works normally from the second request onward. 
I added this test case to cover that scenario, 

`esn-sabre` issue: https://github.com/linagora/esn-sabre/pull/367