### PR TITLE
chore(sabre-v4): provision resource calendar before RSVP update

### DIFF
--- a/src/test/java/com/linagora/dav/contracts/cal/ResourceAMQPMessageContract.java
+++ b/src/test/java/com/linagora/dav/contracts/cal/ResourceAMQPMessageContract.java
@@ -62,6 +62,9 @@ public abstract class ResourceAMQPMessageContract {
         calDavClient = new CalDavClient(dockerExtension().davHttpClient());
     }
 
+    protected void afterResourceSetup(OpenPaaSResource resource) {
+    }
+
     @Test
     void shouldReceiveMessageFromEventResourceCreatedExchange() throws IOException {
         dockerExtension().getChannel().queueBind(QUEUE_NAME, "resource:calendar:event:created", "");
@@ -72,6 +75,7 @@ public abstract class ResourceAMQPMessageContract {
             .getTwakeCalendarProvisioningService()
             .createResource("projector", "This is a projector", testUser)
             .block();
+        afterResourceSetup(resource);
 
         String eventUid = UUID.randomUUID().toString();
         String calendarData = generateCalendarData(
@@ -157,6 +161,7 @@ public abstract class ResourceAMQPMessageContract {
             .getTwakeCalendarProvisioningService()
             .createResource("projector", "This is a projector", testUser)
             .block();
+        afterResourceSetup(resource);
 
         String eventUid = UUID.randomUUID().toString();
         String calendarData = generateCalendarData(
@@ -259,6 +264,7 @@ public abstract class ResourceAMQPMessageContract {
             .getTwakeCalendarProvisioningService()
             .createResource("projector", "This is a projector", testUser)
             .block();
+        afterResourceSetup(resource);
 
         String eventUid = UUID.randomUUID().toString();
         String calendarData = generateCalendarData(

--- a/src/test/java/com/linagora/dav/sabrev4/cal/SabreV4ResourceAMQPMessageTest.java
+++ b/src/test/java/com/linagora/dav/sabrev4/cal/SabreV4ResourceAMQPMessageTest.java
@@ -18,9 +18,12 @@
 
 package com.linagora.dav.sabrev4.cal;
 
+import static com.linagora.dav.TestUtil.TWAKE_CALENDAR_TOKEN_HEADER;
+
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linagora.dav.DockerTwakeCalendarExtensionV4;
+import com.linagora.dav.OpenPaaSResource;
 import com.linagora.dav.contracts.cal.ResourceAMQPMessageContract;
 
 public class SabreV4ResourceAMQPMessageTest extends ResourceAMQPMessageContract {
@@ -30,5 +33,18 @@ public class SabreV4ResourceAMQPMessageTest extends ResourceAMQPMessageContract 
     @Override
     public DockerTwakeCalendarExtensionV4 dockerExtension() {
         return dockerExtension;
+    }
+
+    @Override
+    protected void afterResourceSetup(OpenPaaSResource resource) {
+        // Sabre 4.1.5 lazily provisions the technical-token principal on the first DAV request.
+        dockerExtension().davHttpClient()
+            .headers(headers -> headers
+                .add(TWAKE_CALENDAR_TOKEN_HEADER, dockerExtension().twakeCalendarProvisioningService().generateToken())
+                .add("Accept", "application/json"))
+            .get()
+            .uri("/calendars/" + resource.id() + ".json")
+            .responseSingle((response, responseContent) -> responseContent.asString().then())
+            .block();
     }
 }


### PR DESCRIPTION
Sabre 4.1.5 still lazily provisions