### PR TITLE
ISSUE-289 test(team-calendar): cover classified public visibility

### DIFF
--- a/Dockerfile.sabre4_7
+++ b/Dockerfile.sabre4_7
@@ -1,4 +1,4 @@
-ARG SABRE_4_7_IMAGE="linagora/esn-sabre-pr:416"
+ARG SABRE_4_7_IMAGE="linagora/esn-sabre:2.4.3"
 
 FROM ${SABRE_4_7_IMAGE}
 

--- a/Dockerfile.sabre4_7
+++ b/Dockerfile.sabre4_7
@@ -1,4 +1,4 @@
-ARG SABRE_4_7_IMAGE="linagora/esn-sabre:2.4.3"
+ARG SABRE_4_7_IMAGE="linagora/esn-sabre-pr:416"
 
 FROM ${SABRE_4_7_IMAGE}
 

--- a/src/test/java/com/linagora/dav/OpenPaaSTeamCalendar.java
+++ b/src/test/java/com/linagora/dav/OpenPaaSTeamCalendar.java
@@ -18,17 +18,7 @@
 
 package com.linagora.dav;
 
-import org.bson.Document;
-
 public record OpenPaaSTeamCalendar(String id, String name, String displayName, String domainName) {
-    public static OpenPaaSTeamCalendar fromDocument(Document document) {
-        return new OpenPaaSTeamCalendar(
-            document.getObjectId("_id").toString(),
-            document.getString("name"),
-            document.getString("displayName"),
-            document.getString("domainName"));
-    }
-
     public String email() {
         return id + "@" + domainName;
     }

--- a/src/test/java/com/linagora/dav/TwakeCalendarProvisioningService.java
+++ b/src/test/java/com/linagora/dav/TwakeCalendarProvisioningService.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.bson.Document;
 import org.bson.types.ObjectId;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Updates;
 import com.mongodb.reactivestreams.client.MongoClient;
@@ -37,6 +38,7 @@ import com.mongodb.reactivestreams.client.MongoCollection;
 import com.mongodb.reactivestreams.client.MongoDatabase;
 
 import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
 
@@ -45,6 +47,7 @@ public class TwakeCalendarProvisioningService {
     public static final String DEFAULT_DOMAIN = "open-paas.org";
 
     private static final TechnicalTokenService technicalTokenService = new TechnicalTokenService.Impl("technicalTokenSecret", Duration.ofSeconds(3600));
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private final MongoDatabase database;
     private final HttpClient httpClient;
@@ -109,20 +112,32 @@ public class TwakeCalendarProvisioningService {
     }
 
     public Mono<OpenPaaSTeamCalendar> createTeamCalendar(String name, String displayName, String domainName) {
-        Document domain = createDomainIfNotExists(domainName);
-        Document teamCalendarToSave = new Document()
-            .append("name", name)
-            .append("displayName", displayName)
-            .append("domainId", domain.getObjectId("_id"))
-            .append("domainName", domainName)
-            .append("timestamps", new Document()
-                .append("creation", Date.from(Instant.now()))
-                .append("updatedAt", Date.from(Instant.now())));
+        createDomainIfNotExists(domainName);
+        return httpClient.headers(headers -> headers.add(HttpHeaderNames.CONTENT_TYPE, "application/json"))
+            .post()
+            .uri("/domains/" + domainName + "/team-calendars")
+            .send(Mono.just(Unpooled.wrappedBuffer(OBJECT_MAPPER.createObjectNode()
+                .put("name", name)
+                .put("displayName", displayName)
+                .toString().getBytes(StandardCharsets.UTF_8))))
+            .responseSingle((response, responseContent) -> responseContent.asString(StandardCharsets.UTF_8)
+                .switchIfEmpty(Mono.just(StringUtils.EMPTY))
+                .flatMap(responseBody -> {
+                    if (response.status().code() == 201) {
+                        return parseTeamCalendar(responseBody);
+                    }
+                    return Mono.error(new RuntimeException("Failed to create team calendar through webadmin:"
+                        + response.status().code() + " " + responseBody));
+                }));
+    }
 
-        return Mono.from(database.getCollection("team_calendars").insertOne(teamCalendarToSave))
-            .flatMap(success -> Mono.from(
-                database.getCollection("team_calendars").find(new Document("_id", success.getInsertedId())).first()))
-            .map(OpenPaaSTeamCalendar::fromDocument);
+    private Mono<OpenPaaSTeamCalendar> parseTeamCalendar(String responseBody) {
+        return Mono.fromCallable(() -> OBJECT_MAPPER.readTree(responseBody))
+            .map(json -> new OpenPaaSTeamCalendar(
+                json.path("id").asText(),
+                json.path("name").asText(),
+                json.path("displayName").asText(),
+                json.path("domainName").asText()));
     }
 
     private Mono<OpenPaaSResource> createResource(String name, String description, OpenPaasUser admin, ObjectId domainId) {

--- a/src/test/java/com/linagora/dav/contracts/TeamCalendarContract.java
+++ b/src/test/java/com/linagora/dav/contracts/TeamCalendarContract.java
@@ -19,6 +19,7 @@
 package com.linagora.dav.contracts;
 
 import static io.restassured.RestAssured.given;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -28,6 +29,8 @@ import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.xmlunit.assertj3.XmlAssert;
 
 import com.linagora.dav.CalDavClient;
@@ -417,6 +420,222 @@ public abstract class TeamCalendarContract {
         assertThat(response.body())
             .as("Non-member Bob should see Alice's event because the team calendar is public")
             .contains(eventUid);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"PRIVATE", "CONFIDENTIAL"})
+    void publicReadTeamCalendarShouldExposeClassifiedMemberEventDetailsToMember(String eventClass) {
+        // Given Alice and Bob are members of a team calendar
+        OpenPaasUser alice = dockerExtension().newTestUser();
+        OpenPaasUser bob = dockerExtension().newTestUser();
+        OpenPaaSTeamCalendar teamCalendar = newTeamCalendar("operations", "Operations Team");
+        CalendarURL aliceDelegatedCalendar = delegateTeamCalendarTo(teamCalendar, alice, DelegationRight.READ_WRITE);
+        CalendarURL bobDelegatedCalendar = delegateTeamCalendarTo(teamCalendar, bob, DelegationRight.READ);
+        // And the team calendar is public-read
+        calDavClient.updateTeamCalendarAcl(teamCalendar, PUBLIC_READ_RIGHT);
+        String eventUid = "team-event-" + UUID.randomUUID();
+
+        // When Alice creates a classified event in the team calendar
+        calDavClient.upsertCalendarEvent(alice, aliceDelegatedCalendar, eventUid,
+            """
+                BEGIN:VCALENDAR
+                VERSION:2.0
+                PRODID:-//Example Corp.//CalDAV Client//EN
+                BEGIN:VEVENT
+                UID:{eventUid}
+                DTSTAMP:20300101T080000Z
+                DTSTART:20300110T090000Z
+                DTEND:20300110T100000Z
+                ORGANIZER:mailto:{organizerEmail}
+                SUMMARY:Sensitive {eventClass} team event
+                DESCRIPTION:Sensitive {eventClass} team details
+                LOCATION:Sensitive {eventClass} room
+                CLASS:{eventClass}
+                END:VEVENT
+                END:VCALENDAR
+                """.replace("{eventUid}", eventUid)
+                .replace("{organizerEmail}", alice.email())
+                .replace("{eventClass}", eventClass));
+
+        // Then Bob can read the classified event details from the JSON time-range REPORT on his delegated team calendar
+        String body = given()
+            .header("Authorization", OpenPaasUser.impersonatedBasicAuth(bob.email()))
+            .header("Depth", 0)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .body("""
+                {
+                    "match": {
+                        "start": "20300110T000000",
+                        "end": "20300110T235959"
+                    }
+                }
+                """)
+        .when()
+            .request("REPORT", bobDelegatedCalendar.asUri() + ".json")
+        .then()
+            .statusCode(200)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(body)
+            .node("_embedded.dav:item").isArray().hasSizeGreaterThanOrEqualTo(1);
+        assertThat(body)
+            .as("Team calendar member Bob should see classified event details")
+            .contains(eventUid,
+                "Sensitive {eventClass} team event".replace("{eventClass}", eventClass),
+                "Sensitive {eventClass} team details".replace("{eventClass}", eventClass),
+                "Sensitive {eventClass} room".replace("{eventClass}", eventClass));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"PRIVATE", "CONFIDENTIAL"})
+    void publicReadTeamCalendarShouldNotExposeClassifiedMemberEventDetailsToNonMember(String eventClass) {
+        // Given Alice creates a classified event in a publicly readable team calendar while Charlie is not a member
+        OpenPaasUser alice = dockerExtension().newTestUser();
+        OpenPaasUser charlie = dockerExtension().newTestUser();
+        OpenPaasUser attendee = dockerExtension().newTestUser();
+        OpenPaaSTeamCalendar teamCalendar = newTeamCalendar("operations", "Operations Team");
+        CalendarURL aliceDelegatedCalendar = delegateTeamCalendarTo(teamCalendar, alice, DelegationRight.READ_WRITE);
+        CalendarURL teamCalendarCanonicalUrl = CalendarURL.from(teamCalendar.id());
+        calDavClient.updateTeamCalendarAcl(teamCalendar, PUBLIC_READ_RIGHT);
+        String eventUid = "team-event-" + UUID.randomUUID();
+        calDavClient.upsertCalendarEvent(alice, aliceDelegatedCalendar, eventUid,
+            """
+                BEGIN:VCALENDAR
+                VERSION:2.0
+                PRODID:-//Example Corp.//CalDAV Client//EN
+                BEGIN:VEVENT
+                UID:{eventUid}
+                DTSTAMP:20300101T080000Z
+                DTSTART:20300110T090000Z
+                DTEND:20300110T100000Z
+                ORGANIZER:mailto:{organizerEmail}
+                ATTENDEE;PARTSTAT=NEEDS-ACTION:mailto:{attendeeEmail}
+                SUMMARY:Sensitive {eventClass} team event
+                DESCRIPTION:Sensitive {eventClass} team details
+                LOCATION:Sensitive {eventClass} room
+                CLASS:{eventClass}
+                END:VEVENT
+                END:VCALENDAR
+                """.replace("{eventUid}", eventUid)
+                .replace("{organizerEmail}", alice.email())
+                .replace("{attendeeEmail}", attendee.email())
+                .replace("{eventClass}", eventClass));
+
+        // When Charlie requests a JSON time-range REPORT from the public team calendar
+        String body = given()
+            .header("Authorization", OpenPaasUser.impersonatedBasicAuth(charlie.email()))
+            .header("Depth", 0)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .body("""
+                {
+                    "match": {
+                        "start": "20300110T000000",
+                        "end": "20300110T235959"
+                    }
+                }
+                """)
+        .when()
+            .request("REPORT", teamCalendarCanonicalUrl.asUri() + ".json")
+        .then()
+            .statusCode(200)
+            .extract()
+            .body()
+            .asString();
+
+        // Then Charlie can read the public calendar but cannot see classified event details in the JSON response
+        assertThatJson(body)
+            .node("_embedded.dav:item").isArray().hasSizeGreaterThanOrEqualTo(1);
+        assertThat(body)
+            .as("Non-member Charlie should not see classified event sensitive details")
+            .doesNotContain(
+                "Sensitive {eventClass} team event".replace("{eventClass}", eventClass),
+                "Sensitive {eventClass} team details".replace("{eventClass}", eventClass),
+                "Sensitive {eventClass} room".replace("{eventClass}", eventClass),
+                attendee.email());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"PRIVATE", "CONFIDENTIAL"})
+    void publicReadTeamCalendarShouldNotExposeClassifiedMemberEventDetailsInCalendarDataToNonMember(String eventClass) {
+        // Given Alice is a member of a team calendar while Charlie is not a member
+        OpenPaasUser alice = dockerExtension().newTestUser();
+        OpenPaasUser charlie = dockerExtension().newTestUser();
+        OpenPaasUser attendee = dockerExtension().newTestUser();
+        OpenPaaSTeamCalendar teamCalendar = newTeamCalendar("operations", "Operations Team");
+        CalendarURL aliceDelegatedCalendar = delegateTeamCalendarTo(teamCalendar, alice, DelegationRight.READ_WRITE);
+        CalendarURL teamCalendarCanonicalUrl = CalendarURL.from(teamCalendar.id());
+        // And the team calendar is public-read
+        calDavClient.updateTeamCalendarAcl(teamCalendar, PUBLIC_READ_RIGHT);
+        String eventUid = "team-event-" + UUID.randomUUID();
+
+        // When Alice creates a classified event in the team calendar
+        calDavClient.upsertCalendarEvent(alice, aliceDelegatedCalendar, eventUid,
+            """
+                BEGIN:VCALENDAR
+                VERSION:2.0
+                PRODID:-//Example Corp.//CalDAV Client//EN
+                BEGIN:VEVENT
+                UID:{eventUid}
+                DTSTAMP:20300101T080000Z
+                DTSTART:20300110T090000Z
+                DTEND:20300110T100000Z
+                ORGANIZER:mailto:{organizerEmail}
+                ATTENDEE;PARTSTAT=NEEDS-ACTION:mailto:{attendeeEmail}
+                SUMMARY:Sensitive {eventClass} team event
+                DESCRIPTION:Sensitive {eventClass} team details
+                LOCATION:Sensitive {eventClass} room
+                CLASS:{eventClass}
+                END:VEVENT
+                END:VCALENDAR
+                """.replace("{eventUid}", eventUid)
+                .replace("{organizerEmail}", alice.email())
+                .replace("{attendeeEmail}", attendee.email())
+                .replace("{eventClass}", eventClass));
+
+        // When Charlie requests XML CalDAV calendar-data from the public team calendar
+        String body = given()
+            .header("Authorization", OpenPaasUser.impersonatedBasicAuth(charlie.email()))
+            .header("Depth", 1)
+            .header("Content-Type", "application/xml")
+            .header("Accept", "application/xml")
+            .body("""
+                <c:calendar-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+                    <d:prop>
+                        <d:getetag />
+                        <c:calendar-data/>
+                    </d:prop>
+                    <c:filter>
+                        <c:comp-filter name="VCALENDAR">
+                            <c:comp-filter name="VEVENT">
+                                <c:prop-filter name="UID">
+                                    <c:text-match collation="i;octet">{eventUid}</c:text-match>
+                                </c:prop-filter>
+                            </c:comp-filter>
+                        </c:comp-filter>
+                    </c:filter>
+                </c:calendar-query>
+                """.replace("{eventUid}", eventUid))
+        .when()
+            .request("REPORT", teamCalendarCanonicalUrl.asUri().toString())
+        .then()
+            .statusCode(207)
+            .extract()
+            .body()
+            .asString();
+
+        // Then Charlie can read the public calendar but cannot see classified event details in the XML calendar-data response
+        assertThat(body)
+            .as("Non-member Charlie should not see classified event sensitive details in XML calendar-data")
+            .contains(eventUid)
+            .doesNotContain(
+                "Sensitive {eventClass} team event".replace("{eventClass}", eventClass),
+                "Sensitive {eventClass} team details".replace("{eventClass}", eventClass),
+                "Sensitive {eventClass} room".replace("{eventClass}", eventClass),
+                attendee.email());
     }
 
     @Test


### PR DESCRIPTION
resolve https://github.com/linagora/twake-calendar-integration-tests/issues/289

Add parameterized integration coverage for PRIVATE and CONFIDENTIAL events in public-read team calendars. Verify members can still read classified event details, while non-members do not receive sensitive summary, description, location, or attendee details through JSON time-range REPORT or XML calendar-data REPORT responses.