### PR TITLE
Reproduce TCALENDAR-925: broken event counter via X-Http-Method-Override

### DIFF
--- a/Dockerfile.sabre4_7
+++ b/Dockerfile.sabre4_7
@@ -1,4 +1,4 @@
-ARG SABRE_4_7_IMAGE="linagora/esn-sabre:2.4.3"
+ARG SABRE_4_7_IMAGE="linagora/esn-sabre:2.4.3.2"
 
 FROM ${SABRE_4_7_IMAGE}
 

--- a/src/test/java/com/linagora/dav/CalDavClient.java
+++ b/src/test/java/com/linagora/dav/CalDavClient.java
@@ -410,6 +410,33 @@ public class CalDavClient {
             }).block();
     }
 
+    /**
+     * Sends an ITIP request the way the imap.linagora.com web client does: a POST to the event URL
+     * carrying an "X-Http-Method-Override: ITIP" header, rather than using the custom ITIP verb.
+     * The server's XHttpMethodOverridePlugin is expected to route it through the ITIP handler.
+     */
+    public void sendITIPViaMethodOverride(OpenPaasUser openPaaSUser, String attendeeEventUid, CounterRequest counterRequest) {
+        URI uri = URI.create("/calendars/" + openPaaSUser.id() + "/" + openPaaSUser.id() + "/" + attendeeEventUid + ".ics");
+        httpClient.headers(headers -> openPaaSUser.impersonatedBasicAuth(headers)
+                .add("Content-Type", "application/calendar+json")
+                .add("Accept", "application/json, text/plain, */*")
+                .add("X-Http-Method-Override", "ITIP"))
+            .post()
+            .uri(uri.toString())
+            .send(Mono.just(Unpooled.wrappedBuffer(counterRequest.toJson().getBytes(StandardCharsets.UTF_8))))
+            .responseSingle((response, responseContent) -> {
+                if (response.status().code() == 204) {
+                    return Mono.empty();
+                }
+                return responseContent.asString(StandardCharsets.UTF_8)
+                    .switchIfEmpty(Mono.just(StringUtils.EMPTY))
+                    .flatMap(responseBody -> Mono.error(new RuntimeException("""
+                        Unexpected status code: %d when posting calendar object '%s'
+                        %s
+                        """.formatted(response.status().code(), uri.toString(), responseBody))));
+            }).block();
+    }
+
     public void grantDelegation(OpenPaasUser user, String calendarId, OpenPaasUser delegatedUser, DelegationRight right) {
         grantDelegations(user, calendarId, Map.of(delegatedUser, right));
     }

--- a/src/test/java/com/linagora/dav/contracts/cal/EmailAMQPMessageContract.java
+++ b/src/test/java/com/linagora/dav/contracts/cal/EmailAMQPMessageContract.java
@@ -747,6 +747,142 @@ public abstract class EmailAMQPMessageContract {
     }
 
     @Test
+    void shouldReceiveNotificationEmailMessageOnEventCounterSentViaMethodOverride() {
+        // Reproduces TCALENDAR-925: the imap.linagora.com web client submits a COUNTER as a POST
+        // to the event URL carrying "X-Http-Method-Override: ITIP", not the raw ITIP verb.
+        // The XHttpMethodOverridePlugin must expose the overridden method to downstream plugins so
+        // that AMQPSchedulePlugin publishes the organizer notification. Without that, the COUNTER
+        // silently falls into async buffering and is never published, so the organizer is never
+        // notified of the proposed new time.
+        String eventUid = UUID.randomUUID().toString();
+        String initialCalendarData = generateCalendarData(
+            eventUid,
+            bob.email(),
+            alice.email(),
+            "Sprint planning #01",
+            "Twake Meeting Room",
+            "This is a meeting to discuss the sprint planning for the next week.",
+            "30250411T100000",
+            "30250411T110000");
+        calDavClient.upsertCalendarEvent(bob, eventUid, initialCalendarData);
+
+        String attendeeEventId = awaitAtMost.until(() -> calDavClient.findFirstEventId(alice), Optional::isPresent).get();
+        BlockingQueue<JsonNode> messages = listenToQueue();
+
+        String updatedCalendarData = generateCounterCalendarData(
+            eventUid,
+            bob.email(),
+            alice.email(),
+            "Sprint planning #01",
+            "Twake Meeting Room",
+            "This is a meeting to discuss the sprint planning for the next week.",
+            "30250411T150000",
+            "30250411T160000");
+        CalDavClient.CounterRequest counterRequest = new CalDavClient.CounterRequest(
+            updatedCalendarData,
+            alice.email(),
+            bob.email(),
+            eventUid,
+            1);
+        calDavClient.sendITIPViaMethodOverride(alice, attendeeEventId, counterRequest);
+        String expectedEventIcs = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            METHOD:COUNTER
+            PRODID:-//Sabre//Sabre VObject 4.1.3//EN
+            CALSCALE:GREGORIAN
+            BEGIN:VTIMEZONE
+            TZID:Asia/Ho_Chi_Minh
+            BEGIN:STANDARD
+            TZOFFSETFROM:+0700
+            TZOFFSETTO:+0700
+            TZNAME:ICT
+            DTSTART:19700101T000000
+            END:STANDARD
+            END:VTIMEZONE
+            BEGIN:VEVENT
+            UID:{eventUid}
+            DTSTAMP:30250411T022032Z
+            SEQUENCE:1
+            DTSTART;TZID=Asia/Ho_Chi_Minh:30250411T150000
+            DTEND;TZID=Asia/Ho_Chi_Minh:30250411T160000
+            SUMMARY:Sprint planning #01
+            LOCATION:Twake Meeting Room
+            DESCRIPTION:This is a meeting to discuss the sprint planning for the next w
+             eek.
+            ORGANIZER;CN=Van Tung TRAN:mailto:{organizerEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;CN=Benoît TELLIER:mailto:{attendeeEmail}
+            END:VEVENT
+            END:VCALENDAR
+            """.replace("{organizerEmail}", bob.email())
+            .replace("{attendeeEmail}", alice.email())
+            .replace("{eventUid}", eventUid);
+        String expectedOldEventIcs = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Sabre//Sabre VObject 4.1.3//EN
+            CALSCALE:GREGORIAN
+            BEGIN:VTIMEZONE
+            TZID:Asia/Ho_Chi_Minh
+            BEGIN:STANDARD
+            TZOFFSETFROM:+0700
+            TZOFFSETTO:+0700
+            TZNAME:ICT
+            DTSTART:19700101T000000
+            END:STANDARD
+            END:VTIMEZONE
+            BEGIN:VEVENT
+            UID:{eventUid}
+            DTSTAMP:30250411T022032Z
+            SEQUENCE:1
+            DTSTART;TZID=Asia/Ho_Chi_Minh:30250411T100000
+            DTEND;TZID=Asia/Ho_Chi_Minh:30250411T110000
+            SUMMARY:Sprint planning #01
+            LOCATION:Twake Meeting Room
+            DESCRIPTION:This is a meeting to discuss the sprint planning for the next w
+             eek.
+            ORGANIZER;CN=Van Tung TRAN:mailto:{organizerEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;CN=Benoît TELLIER;SCHEDULE-STATUS=1.1:mailto:{attendeeEmail}
+            END:VEVENT
+            END:VCALENDAR
+            """.replace("{organizerEmail}", bob.email())
+            .replace("{attendeeEmail}", alice.email())
+            .replace("{eventUid}", eventUid);
+
+        String expected = """
+            {
+              "senderEmail": "{attendeeEmail}",
+              "recipientEmail": "{organizerEmail}",
+              "method": "COUNTER",
+              "event": "${json-unit.any-string}",
+              "notify": true,
+              "calendarURI": "{attendeeId}",
+              "eventPath": "/calendars/{organizerId}/{organizerId}/{eventUid}.ics",
+              "oldEvent": "${json-unit.any-string}"
+            }
+            """.replace("{organizerEmail}", bob.email())
+            .replace("{attendeeEmail}", alice.email())
+            .replace("{organizerId}", bob.id())
+            .replace("{attendeeId}", alice.id())
+            .replace("{eventUid}", eventUid)
+            .replace("{attendeeEventId}", attendeeEventId);
+
+        awaitAtMost.untilAsserted(() ->
+            assertThat(messages)
+                .filteredOn(message -> bob.email().equals(message.path("recipientEmail").asText()))
+                .anySatisfy(message -> {
+                    assertThatJson(message.toString())
+                        .isEqualTo(expected);
+
+                    assertThatCalendar(message.path("event").asText()).isEqualTo(expectedEventIcs);
+
+                    assertThatCalendar(message.path("oldEvent").asText())
+                        .ignoringParticipantScheduleStatus()
+                        .isEqualTo(expectedOldEventIcs);
+                }));
+    }
+
+    @Test
     void shouldReceiveNotificationEmailMessageOnEventCounterWithExternalRecipient() {
         String externalBobEmail = "bob-organizer-" + UUID.randomUUID() + "@external-domain.com";
 


### PR DESCRIPTION
Closes #294

Reproduces [TCALENDAR-925](https://github.com/linagora/esn-sabre/pull/420) with a failing integration test.

## Context

The imap.linagora.com web client submits an ITIP **COUNTER** as a `POST` to the event URL carrying an `X-Http-Method-Override: ITIP` header, rather than using the raw `ITIP` verb. Server-side, `XHttpMethodOverridePlugin` re-invokes the request with the overridden method but does **not** expose that method to the rest of the request chain, so the downstream `AMQPSchedulePlugin::scheduleLocalDelivery` still sees the original `POST`. The COUNTER therefore falls into async buffering, never gets flushed (an ITIP path triggers no file write), and the organizer notification is never published.

## Reproduction

`EmailAMQPMessageContract.shouldReceiveNotificationEmailMessageOnEventCounterSentViaMethodOverride`:

- Bob invites Alice; Alice sends a COUNTER via `POST` + `X-Http-Method-Override: ITIP` to her copy of the event (new `CalDavClient.sendITIPViaMethodOverride` helper).
- The test expects the organizer notification on the `calendar:event:notificationEmail:send` queue — the **same assertions** already passing in `shouldReceiveNotificationEmailMessageOnEventCounter` when the raw `ITIP` verb is used.

Against the current server image the queue stays empty and the test fails, confirming TCALENDAR-925. It is expected to pass once esn-sabre PR #420 is released.

---
*Generated automatically*