### PR TITLE
test(cal): cover organizer PUT `STATUS:CANCELLED`

### DIFF
--- a/src/test/java/com/linagora/dav/contracts/cal/EmailAMQPMessageContract.java
+++ b/src/test/java/com/linagora/dav/contracts/cal/EmailAMQPMessageContract.java
@@ -543,6 +543,61 @@ public abstract class EmailAMQPMessageContract {
     }
 
     @Test
+    void shouldReceiveCancelNotificationEmailMessageWhenOrganizerPutsCancelledStatus() {
+        String eventUid = UUID.randomUUID().toString();
+        String calendarData = generateCalendarData(
+            eventUid,
+            bob.email(),
+            alice.email(),
+            "Sprint planning #01",
+            "Twake Meeting Room",
+            "This is a meeting to discuss the sprint planning for the next week.",
+            "30250411T100000",
+            "30250411T110000");
+        calDavClient.upsertCalendarEvent(bob, eventUid, calendarData);
+
+        String attendeeEventId = awaitAtMost.until(() -> calDavClient.findFirstEventId(alice), Optional::isPresent).get();
+        URI attendeeEventUri = URI.create("/calendars/" + alice.id() + "/" + alice.id() + "/" + attendeeEventId + ".ics");
+        BlockingQueue<JsonNode> messages = listenToQueue();
+
+        String cancelledCalendarData = calendarData
+            .replace("SEQUENCE:1", "SEQUENCE:2")
+            .replace("END:VEVENT", "STATUS:CANCELLED\nEND:VEVENT");
+        calDavClient.upsertCalendarEvent(bob, eventUid, cancelledCalendarData);
+
+        awaitAtMost.untilAsserted(() -> assertThat(calDavClient.getCalendarEvent(alice, attendeeEventUri))
+            .contains("STATUS:CANCELLED"));
+
+        String expected = """
+            {
+              "senderEmail": "{organizerEmail}",
+              "recipientEmail": "{attendeeEmail}",
+              "method": "CANCEL",
+              "event": "${json-unit.any-string}",
+              "notify": true,
+              "calendarURI": "{organizerId}",
+              "eventPath": "/calendars/{attendeeId}/{attendeeId}/{attendeeEventId}.ics"
+            }
+            """.replace("{organizerEmail}", bob.email())
+            .replace("{attendeeEmail}", alice.email())
+            .replace("{organizerId}", bob.id())
+            .replace("{attendeeId}", alice.id())
+            .replace("{attendeeEventId}", attendeeEventId);
+
+        awaitAtMost.untilAsserted(() ->
+            assertThat(messages)
+                .filteredOn(message -> alice.email().equals(message.path("recipientEmail").asText()))
+                .anySatisfy(message -> {
+                    assertThatJson(message.toString())
+                        .when(Option.IGNORING_EXTRA_FIELDS)
+                        .isEqualTo(expected);
+
+                    assertThat(message.path("event").asText())
+                        .contains("METHOD:CANCEL");
+                }));
+    }
+
+    @Test
     void shouldPreservePubliclyCreatedMetadataOnCancelNotificationEmailMessage() {
         String eventUid = UUID.randomUUID().toString();
         String calendarData = """

--- a/src/test/java/com/linagora/dav/contracts/cal/SchedulingContract.java
+++ b/src/test/java/com/linagora/dav/contracts/cal/SchedulingContract.java
@@ -322,7 +322,6 @@ public abstract class SchedulingContract {
         String cancelledOrganizerEventIcs = organizerEventIcs
             .replace("DTSTAMP:20351003T080000Z", "DTSTAMP:20351003T090000Z")
             .replace("SEQUENCE:1", "SEQUENCE:2")
-            .replace("SUMMARY:Meeting before cancellation", "SUMMARY:Meeting cancelled by PUT")
             .replace("END:VEVENT", "STATUS:CANCELLED\nEND:VEVENT");
         calDavClient.upsertCalendarEvent(bob, organizerEventUid, cancelledOrganizerEventIcs);
 
@@ -334,15 +333,11 @@ public abstract class SchedulingContract {
             assertThat(aliceEventIcs)
                 .contains("UID:" + organizerEventUid)
                 .contains("SEQUENCE:2")
-                .contains("SUMMARY:Meeting cancelled by PUT")
-                .contains("STATUS:CANCELLED")
-                .doesNotContain("SUMMARY:Meeting before cancellation");
+                .contains("STATUS:CANCELLED");
             assertThat(cedricEventIcs)
                 .contains("UID:" + organizerEventUid)
                 .contains("SEQUENCE:2")
-                .contains("SUMMARY:Meeting cancelled by PUT")
-                .contains("STATUS:CANCELLED")
-                .doesNotContain("SUMMARY:Meeting before cancellation");
+                .contains("STATUS:CANCELLED");
         });
     }
 

--- a/src/test/java/com/linagora/dav/contracts/cal/SchedulingContract.java
+++ b/src/test/java/com/linagora/dav/contracts/cal/SchedulingContract.java
@@ -288,6 +288,65 @@ public abstract class SchedulingContract {
     }
 
     @Test
+    void eventCancellationByOrganizerPutShouldPropagateCancelledEventToAllAttendees() {
+        // Given Bob creates an event with Alice and Cedric as attendees
+        String organizerEventUid = "event-" + UUID.randomUUID();
+        String organizerEventIcs = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Example Corp.//CalDAV Client//EN
+            BEGIN:VEVENT
+            UID:{organizerEventUid}
+            DTSTAMP:20351003T080000Z
+            SEQUENCE:1
+            DTSTART:20351005T090000Z
+            DTEND:20351005T100000Z
+            SUMMARY:Meeting before cancellation
+            ORGANIZER:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=ACCEPTED;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:{bobEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:{aliceEmail}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL:mailto:{cedricEmail}
+            END:VEVENT
+            END:VCALENDAR
+            """
+            .replace("{organizerEventUid}", organizerEventUid)
+            .replace("{bobEmail}", bob.email())
+            .replace("{aliceEmail}", alice.email())
+            .replace("{cedricEmail}", cedric.email());
+
+        calDavClient.upsertCalendarEvent(bob, organizerEventUid, organizerEventIcs);
+        URI aliceCalendarEventUri = awaitCalendarObjectUriByEventUid(alice, CalendarURL.from(alice.id()), organizerEventUid);
+        URI cedricCalendarEventUri = awaitCalendarObjectUriByEventUid(cedric, CalendarURL.from(cedric.id()), organizerEventUid);
+
+        // When Bob cancels the event through PUT rather than DELETE
+        String cancelledOrganizerEventIcs = organizerEventIcs
+            .replace("DTSTAMP:20351003T080000Z", "DTSTAMP:20351003T090000Z")
+            .replace("SEQUENCE:1", "SEQUENCE:2")
+            .replace("SUMMARY:Meeting before cancellation", "SUMMARY:Meeting cancelled by PUT")
+            .replace("END:VEVENT", "STATUS:CANCELLED\nEND:VEVENT");
+        calDavClient.upsertCalendarEvent(bob, organizerEventUid, cancelledOrganizerEventIcs);
+
+        // Then every attendee calendar object is updated with the cancelled event data
+        awaitAtMost.untilAsserted(() -> {
+            String aliceEventIcs = calDavClient.getCalendarEvent(alice, aliceCalendarEventUri);
+            String cedricEventIcs = calDavClient.getCalendarEvent(cedric, cedricCalendarEventUri);
+
+            assertThat(aliceEventIcs)
+                .contains("UID:" + organizerEventUid)
+                .contains("SEQUENCE:2")
+                .contains("SUMMARY:Meeting cancelled by PUT")
+                .contains("STATUS:CANCELLED")
+                .doesNotContain("SUMMARY:Meeting before cancellation");
+            assertThat(cedricEventIcs)
+                .contains("UID:" + organizerEventUid)
+                .contains("SEQUENCE:2")
+                .contains("SUMMARY:Meeting cancelled by PUT")
+                .contains("STATUS:CANCELLED")
+                .doesNotContain("SUMMARY:Meeting before cancellation");
+        });
+    }
+
+    @Test
     void attendeeAcceptanceShouldPropagateToOrganizerCalendar() {
         // Given Bob creates an event with Cedric as attendee
         String organizerEventUid = "event-" + UUID.randomUUID();


### PR DESCRIPTION
This protects scheduling behavior related to issue https://github.com/linagora/twake-calendar-side-service/issues/952  by ensuring cancellation updates are handled consistently across attendee calendars and notification messages, not only through delete flows.


- no need update esn-sabre