### PR TITLE
test(resource): reproduce resource admin participation update failure

### DIFF
--- a/src/test/java/com/linagora/dav/contracts/cal/CalDavResourceParticipationContract.java
+++ b/src/test/java/com/linagora/dav/contracts/cal/CalDavResourceParticipationContract.java
@@ -93,12 +93,7 @@ public abstract class CalDavResourceParticipationContract {
         String eventUid = UUID.randomUUID().toString();
         calDavClient.upsertCalendarEvent(organizer, eventUid, generateCalendarData(eventUid, organizer.email(), resource.id(), "NEEDS-ACTION"));
 
-        CalendarURL mirrorCalendarURL = awaitAtMost.until(() -> calDavClient.findUserCalendars(resourceAdmin)
-                    .filter(url -> !url.base().equals(url.calendarId()))
-                    .next()
-                    .blockOptional(),
-                Optional::isPresent)
-            .orElseThrow(() -> new AssertionError("Resource administrator has no delegated resource calendar"));
+        CalendarURL mirrorCalendarURL = calDavClient.findDelegatedCalendar(resourceAdmin, resource.id());
         URI mirrorEventUri = awaitAtMost.until(
                 () -> calDavClient.findFirstUserCalendarObjectUriByEventUid(resourceAdmin, mirrorCalendarURL, eventUid),
                 Optional::isPresent)

--- a/src/test/java/com/linagora/dav/contracts/cal/CalDavResourceParticipationContract.java
+++ b/src/test/java/com/linagora/dav/contracts/cal/CalDavResourceParticipationContract.java
@@ -33,6 +33,8 @@ import org.testcontainers.shaded.org.awaitility.Awaitility;
 import org.testcontainers.shaded.org.awaitility.core.ConditionFactory;
 
 import com.linagora.dav.CalDavClient;
+import com.linagora.dav.CalDavClient.DelegationRight;
+import com.linagora.dav.CalendarURL;
 import com.linagora.dav.DockerTwakeCalendarExtension;
 import com.linagora.dav.OpenPaaSResource;
 import com.linagora.dav.OpenPaasUser;
@@ -58,7 +60,7 @@ public abstract class CalDavResourceParticipationContract {
 
     @Test
     @Disabled("https://github.com/linagora/esn-sabre/issues/441 - resource administrator lacks {DAV:}write-content on the resource calendar")
-    void resourceAdministratorShouldBeAbleToUpdateParticipation() {
+    void resourceAdministratorShouldBeAbleToUpdateParticipationThroughCanonicalCalendarUrl() {
         OpenPaasUser organizer = dockerExtension().newTestUser();
         OpenPaasUser resourceAdmin = dockerExtension().newTestUser();
         OpenPaaSResource resource = dockerExtension().twakeCalendarProvisioningService()
@@ -74,6 +76,36 @@ public abstract class CalDavResourceParticipationContract {
         String acceptedCalendarData = generateCalendarData(eventUid, organizer.email(), resource.id(), "ACCEPTED");
 
         assertThatCode(() -> calDavClient.upsertCalendarEvent(resourceAdmin, resourceEventUri, acceptedCalendarData))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void resourceAdministratorShouldBeAbleToUpdateParticipationThroughMirrorCalendarUrl() {
+        OpenPaasUser organizer = dockerExtension().newTestUser();
+        OpenPaasUser resourceAdmin = dockerExtension().newTestUser();
+        OpenPaaSResource resource = dockerExtension().twakeCalendarProvisioningService()
+            .createResource("projector", "This is a projector", resourceAdmin)
+            .block();
+
+        String technicalToken = dockerExtension().twakeCalendarProvisioningService().generateToken();
+        calDavClient.grantDelegation(resource.id(), resourceAdmin, DelegationRight.READ_WRITE, technicalToken);
+
+        String eventUid = UUID.randomUUID().toString();
+        calDavClient.upsertCalendarEvent(organizer, eventUid, generateCalendarData(eventUid, organizer.email(), resource.id(), "NEEDS-ACTION"));
+
+        CalendarURL mirrorCalendarURL = awaitAtMost.until(() -> calDavClient.findUserCalendars(resourceAdmin)
+                    .filter(url -> !url.base().equals(url.calendarId()))
+                    .next()
+                    .blockOptional(),
+                Optional::isPresent)
+            .orElseThrow(() -> new AssertionError("Resource administrator has no delegated resource calendar"));
+        URI mirrorEventUri = awaitAtMost.until(
+                () -> calDavClient.findFirstUserCalendarObjectUriByEventUid(resourceAdmin, mirrorCalendarURL, eventUid),
+                Optional::isPresent)
+            .orElseThrow(() -> new AssertionError("Expected event to be present in delegated resource calendar"));
+        String acceptedCalendarData = generateCalendarData(eventUid, organizer.email(), resource.id(), "ACCEPTED");
+
+        assertThatCode(() -> calDavClient.upsertCalendarEvent(resourceAdmin, mirrorEventUri, acceptedCalendarData))
             .doesNotThrowAnyException();
     }
 

--- a/src/test/java/com/linagora/dav/contracts/cal/CalDavResourceParticipationContract.java
+++ b/src/test/java/com/linagora/dav/contracts/cal/CalDavResourceParticipationContract.java
@@ -1,0 +1,111 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.dav.contracts.cal;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+import org.testcontainers.shaded.org.awaitility.core.ConditionFactory;
+
+import com.linagora.dav.CalDavClient;
+import com.linagora.dav.DockerTwakeCalendarExtension;
+import com.linagora.dav.OpenPaaSResource;
+import com.linagora.dav.OpenPaasUser;
+
+public abstract class CalDavResourceParticipationContract {
+
+    private final ConditionFactory awaitAtMost = Awaitility.with()
+        .pollInterval(Duration.ofMillis(500))
+        .and()
+        .with()
+        .pollDelay(Duration.ofMillis(500))
+        .await()
+        .atMost(30, TimeUnit.SECONDS);
+
+    private CalDavClient calDavClient;
+
+    public abstract DockerTwakeCalendarExtension dockerExtension();
+
+    @BeforeEach
+    void setUp() {
+        calDavClient = new CalDavClient(dockerExtension().davHttpClient());
+    }
+
+    @Test
+    @Disabled("https://github.com/linagora/esn-sabre/issues/441 - resource administrator lacks {DAV:}write-content on the resource calendar")
+    void resourceAdministratorShouldBeAbleToUpdateParticipation() {
+        OpenPaasUser organizer = dockerExtension().newTestUser();
+        OpenPaasUser resourceAdmin = dockerExtension().newTestUser();
+        OpenPaaSResource resource = dockerExtension().twakeCalendarProvisioningService()
+            .createResource("projector", "This is a projector", resourceAdmin)
+            .block();
+
+        String eventUid = UUID.randomUUID().toString();
+        calDavClient.upsertCalendarEvent(organizer, eventUid, generateCalendarData(eventUid, organizer.email(), resource.id(), "NEEDS-ACTION"));
+
+        String resourceEventId = awaitAtMost.until(() -> calDavClient.findFirstEventId(resource.id(), organizer), Optional::isPresent).get();
+
+        URI resourceEventUri = URI.create("/calendars/" + resource.id() + "/" + resource.id() + "/" + resourceEventId + ".ics");
+        String acceptedCalendarData = generateCalendarData(eventUid, organizer.email(), resource.id(), "ACCEPTED");
+
+        assertThatCode(() -> calDavClient.upsertCalendarEvent(resourceAdmin, resourceEventUri, acceptedCalendarData))
+            .doesNotThrowAnyException();
+    }
+
+    private String generateCalendarData(String eventUid, String organizerEmail, String resourceId, String resourcePartStat) {
+        return """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Sabre//Sabre VObject 4.1.3//EN
+            CALSCALE:GREGORIAN
+            BEGIN:VTIMEZONE
+            TZID:Asia/Ho_Chi_Minh
+            BEGIN:STANDARD
+            TZOFFSETFROM:+0700
+            TZOFFSETTO:+0700
+            TZNAME:ICT
+            DTSTART:19700101T000000
+            END:STANDARD
+            END:VTIMEZONE
+            BEGIN:VEVENT
+            UID:{eventUid}
+            SEQUENCE:1
+            DTSTART;TZID=Asia/Ho_Chi_Minh:30250411T100000
+            DTEND;TZID=Asia/Ho_Chi_Minh:30250411T110000
+            SUMMARY:Sprint planning #01
+            ORGANIZER;CN=Van Tung TRAN:mailto:{organizerEmail}
+            ATTENDEE;PARTSTAT=ACCEPTED;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:{organizerEmail}
+            ATTENDEE;PARTSTAT={resourcePartStat};RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=RESOURCE;CN=projector:mailto:{resourceId}@open-paas.org
+            END:VEVENT
+            END:VCALENDAR
+            """.replace("{eventUid}", eventUid)
+            .replace("{organizerEmail}", organizerEmail)
+            .replace("{resourcePartStat}", resourcePartStat)
+            .replace("{resourceId}", resourceId);
+    }
+}

--- a/src/test/java/com/linagora/dav/sabrev4_7/cal/SabreV4CalDavResourceParticipationTest.java
+++ b/src/test/java/com/linagora/dav/sabrev4_7/cal/SabreV4CalDavResourceParticipationTest.java
@@ -1,0 +1,34 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.dav.sabrev4_7.cal;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linagora.dav.DockerTwakeCalendarExtensionV4_7;
+import com.linagora.dav.contracts.cal.CalDavResourceParticipationContract;
+
+public class SabreV4CalDavResourceParticipationTest extends CalDavResourceParticipationContract {
+    @RegisterExtension
+    static DockerTwakeCalendarExtensionV4_7 dockerExtension = new DockerTwakeCalendarExtensionV4_7();
+
+    @Override
+    public DockerTwakeCalendarExtensionV4_7 dockerExtension() {
+        return dockerExtension;
+    }
+}


### PR DESCRIPTION
Closes #309

## Context

Per [linagora/esn-sabre#441](https://github.com/linagora/esn-sabre/issues/441), a resource **administrator** who updates the resource's participation status on an event — by `PUT`-ing the updated ICS onto the resource calendar (`/calendars/{resourceId}/{resourceId}/{event}.ics`) with their own credentials — is rejected with:

```
403 Sabre\DAVACL\Exception\NeedPrivileges
User did not have the required privileges ({DAV:}write-content)
```

although the administrator is expected to be able to manage the resource's participation.

## Change

Adds a contract test (`CalDavResourceParticipationContract`) wired to Sabre 4.7 (`SabreV4CalDavResourceParticipationTest`) that:

1. Has an organizer create an event inviting a resource.
2. Has the resource administrator `PUT` the event back with `PARTSTAT=ACCEPTED` using their own credentials.
3. Expects the call to succeed.

Running it against the current image reproduces the bug (`403 {DAV:}write-content` / `NeedPrivileges`), confirming the report. The test is `@Disabled` pointing at linagora/esn-sabre#441 so CI stays green until the server-side fix ships and the image is adopted; enabling it is then a one-line change.

---
*Generated automatically*
