### PR TITLE
test(caldav): re-enable resource participation update test

### DIFF
--- a/Dockerfile.sabre4_7
+++ b/Dockerfile.sabre4_7
@@ -1,4 +1,4 @@
-ARG SABRE_4_7_IMAGE="linagora/esn-sabre:2.4.4.2"
+ARG SABRE_4_7_IMAGE="linagora/esn-sabre:2.4.4.3"
 
 FROM ${SABRE_4_7_IMAGE}
 

--- a/Dockerfile.tcalendar
+++ b/Dockerfile.tcalendar
@@ -1,4 +1,4 @@
-FROM linagora/twake-calendar-side-service:2.4.4.3
+FROM linagora/twake-calendar-side-service:2.4.4.4
 
 COPY src/test/resources/twake-calendar-side-service-conf/configuration.properties /root/conf/configuration.properties
 COPY src/test/resources/twake-calendar-side-service-conf/opensearch.properties /root/conf/opensearch.properties

--- a/src/test/java/com/linagora/dav/contracts/cal/CalDavResourceParticipationContract.java
+++ b/src/test/java/com/linagora/dav/contracts/cal/CalDavResourceParticipationContract.java
@@ -27,7 +27,6 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.shaded.org.awaitility.Awaitility;
 import org.testcontainers.shaded.org.awaitility.core.ConditionFactory;
@@ -59,7 +58,6 @@ public abstract class CalDavResourceParticipationContract {
     }
 
     @Test
-    @Disabled("https://github.com/linagora/esn-sabre/issues/441 - resource administrator lacks {DAV:}write-content on the resource calendar")
     void resourceAdministratorShouldBeAbleToUpdateParticipationThroughCanonicalCalendarUrl() {
         OpenPaasUser organizer = dockerExtension().newTestUser();
         OpenPaasUser resourceAdmin = dockerExtension().newTestUser();


### PR DESCRIPTION
- Bumped the Sabre test image from `linagora/esn-sabre:2.4.4.2` to `linagora/esn-sabre:2.4.4.3`.
- Bumped the Twake Calendar side-service image from `2.4.4.3` to `2.4.4.4`.
- Removed the `@Disabled` annotation from `resourceAdministratorShouldBeAbleToUpdateParticipationThroughCanonicalCalendarUrl`.
