### PR TITLE
test(caldav): cover private calendar JSON access paths

### DIFF
--- a/src/test/java/com/linagora/dav/contracts/cal/CalDavContract.java
+++ b/src/test/java/com/linagora/dav/contracts/cal/CalDavContract.java
@@ -3027,6 +3027,15 @@ public abstract class CalDavContract {
                 new AuthenticatedEndpoint("GET", "/calendars/" + userId + "/" + userId + "?export", Optional.empty(),
                     Map.of("Accept", "text/calendar")),
 
+                new AuthenticatedEndpoint("GET", "/calendars/" + userId + ".json", Optional.empty(),
+                    Map.of("Accept", "application/json")),
+
+                new AuthenticatedEndpoint("GET", "/calendars/" + userId + "/" + userId + ".json?allEvents=true", Optional.empty(),
+                    Map.of("Accept", "application/json")),
+
+                new AuthenticatedEndpoint("GET", "/calendars/" + userId + "/" + userId + "/fake-event-id.json", Optional.empty(),
+                    Map.of("Accept", "application/json")),
+
                 new AuthenticatedEndpoint("ITIP", "/calendars/" + userId, Optional.of("""
                     {"uid":"fake-itip-uid","sender":"sender@example.com","recipient":"recipient@example.com","method":"REQUEST","ical":"BEGIN:VCALENDAR\\r\\nVERSION:2.0\\r\\nEND:VCALENDAR"}
                     """),
@@ -3052,6 +3061,11 @@ public abstract class CalDavContract {
                 new AuthenticatedEndpoint("PROPPATCH", "/calendars/" + userId + "/" + userId + ".json", Optional.of("""
                     {"id":"%s","dav:name":"Hacked name"}
                     """.formatted(userId)),
+                    Map.of("Accept", "application/json", "Content-Type", "application/json")),
+
+                new AuthenticatedEndpoint("ACL", "/calendars/" + userId + "/" + userId + ".json", Optional.of("""
+                    {"public_right":"{DAV:}read"}
+                    """),
                     Map.of("Accept", "application/json", "Content-Type", "application/json")),
 
                 new AuthenticatedEndpoint("POST", "/calendars/" + userId + "/" + userId,

--- a/src/test/java/com/linagora/dav/contracts/cal/CalendarSharingContract.java
+++ b/src/test/java/com/linagora/dav/contracts/cal/CalendarSharingContract.java
@@ -271,6 +271,61 @@ public abstract class CalendarSharingContract {
         });
     }
 
+    @Test
+    public void cannotReadPrivateCalendarDataWithJsonEventPathsReport() {
+        String eventUid = createEventInBobPrivateCalendar();
+
+        DavResponse response = execute(extension().davHttpClient()
+            .headers(headers -> alice.impersonatedBasicAuth(headers)
+                .add("Accept", "application/json")
+                .add("Content-Type", "application/json"))
+            .request(HttpMethod.valueOf("REPORT"))
+            .uri("/calendars.json")
+            .send(body("""
+                {
+                  "eventPaths": [
+                    "/calendars/{bobId}/{bobId}/{eventUid}.ics"
+                  ]
+                }
+                """.replace("{bobId}", bob.id())
+                .replace("{eventUid}", eventUid))));
+
+        assertPrivateCalendarNotExposed(response, eventUid);
+    }
+
+    @Test
+    public void cannotSyncTokenReportPrivateCalendar() {
+        String eventUid = createEventInBobPrivateCalendar();
+
+        DavResponse response = calDavClient.findEventsBySyncToken(alice,
+            CalendarURL.from(bob.id()),
+            "http://sabre.io/ns/sync/1");
+
+        assertPrivateCalendarNotExposed(response, eventUid);
+    }
+
+    @Test
+    public void cannotReadPrivateCalendarWithAllEventsJsonShortcut() {
+        String eventUid = createEventInBobPrivateCalendar();
+
+        DavResponse response = execute(extension().davHttpClient()
+            .headers(headers -> alice.impersonatedBasicAuth(headers)
+                .add("Accept", "application/json"))
+            .get()
+            .uri(CalendarURL.from(bob.id()).asUri() + ".json?allEvents=true"));
+
+        assertPrivateCalendarNotExposed(response, eventUid);
+    }
+
+    private void assertPrivateCalendarNotExposed(DavResponse response, String eventUid) {
+        assertSoftly(softly -> {
+            softly.assertThat(response.status()).isIn(403, 404);
+            softly.assertThat(response.body()).doesNotContain(eventUid);
+            softly.assertThat(response.body()).doesNotContain("Bob private calendar event");
+            softly.assertThat(response.body()).doesNotContain("ABCXYZ111");
+        });
+    }
+
     private String createEventInBobPrivateCalendar() {
         // Given: Bob sets his calendar as private
         calDavClient.updateCalendarAcl(bob, "");


### PR DESCRIPTION
Add CalDAV integration coverage to ensure private calendar data is not exposed through JSON and sync/report access paths.
